### PR TITLE
Use: express-handlebars for server-side render

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MS-RSL",
   "dependencies": {
     "express": "^4.14.0",
+    "express-handlebars": "^3.0.0",
     "express-session": "^1.14.1",
     "morgan": "^1.5.1",
     "prop-types": "^15.5.10",

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -4,6 +4,7 @@
 */
 
 import express from 'express';
+import exphbs from 'express-handlebars';
 import favicon from 'serve-favicon';
 import http from 'http';
 import logger from 'morgan';
@@ -20,6 +21,12 @@ import reducers from '../redux/reducers';
 import routes from '../react/routes';
 
 const app = express();
+
+const hbs = exphbs.create({ defaultLayout: 'main', extname: '.html' });
+
+app.engine('html', hbs.engine);
+
+app.set('view engine', 'html');
 
 // Path is relative to `built/main.js`.
 app.use(favicon(path.join(__dirname, 'favicons', 'favicon-16x16.png')));
@@ -60,27 +67,14 @@ app.get('*', (req, res) => {
 
 		const head = Helmet.rewind();
 
-		const html = `
-			<!DOCTYPE html>
-			<html>
-				<head>
-					${head.title.toString()}
-					<link rel="stylesheet" href="/main.css">
-					<script src="/main.js"></script>
-					<meta charset="utf-8">
-				</head>
-				<script id="react-client-data" type="text/json">
-					${JSON.stringify(preloadedState)}
-				</script>
-				<div id="app" class="app">
-					${reactHtml}
-				</div>
-			</html>
-		`.split('\n').map(line => line.trim()).join('');
-
-		res.write(html);
-
-		res.end();
+		res.render(
+			'react-mount',
+			{
+				headTitleHtml: head.title.toString(),
+				clientData: JSON.stringify(preloadedState),
+				reactHtml
+			}
+		);
 
 	});
 

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		{{{headTitleHtml}}}
+		<link rel="stylesheet" href="/main.css">
+		<script src="/main.js"></script>
+		<meta charset="utf-8">
+	</head>
+	<body>
+		{{{body}}}
+	</body>
+</html>

--- a/views/react-mount.html
+++ b/views/react-mount.html
@@ -1,0 +1,2 @@
+<script id="react-client-data" type="text/json">{{{clientData}}}</script>
+<div id="app" class="app">{{{reactHtml}}}</div>


### PR DESCRIPTION
Fixes console warning `Warning: Text content did not match` owing to mismatch between server-rendered and client-rendered HTML.

#### New dependencies:
- [npm: express-handlebars](https://www.npmjs.com/package/express-handlebars).