### PR TITLE
Trigger: Data fetch if matching route path but different URL

### DIFF
--- a/src/react/utils/fetch-data-on-mount-wrapper.jsx
+++ b/src/react/utils/fetch-data-on-mount-wrapper.jsx
@@ -18,6 +18,22 @@ class FetchDataOnMountWrapper extends React.Component {
 
 	};
 
+	componentWillReceiveProps (nextProps) {
+
+		const fetchReqd =
+			(this.props.match.path === nextProps.match.path) &&
+			(this.props.match.url !== nextProps.match.url);
+
+		if (fetchReqd) {
+
+			const { fetchData, dispatch, match, location } = nextProps;
+
+			fetchData.map(fn => fn(dispatch, match, location));
+
+		}
+
+	}
+
 	shouldComponentUpdate (nextProps) {
 
 		return this.props.error.exists !== nextProps.error.exists;


### PR DESCRIPTION
Using `react-router-dom` `Link` to go to another page with the same route path pattern, e.g. from `/characters/1` to `/characters/2` (which both match `/characters/:uuid`), does not trigger a fetch for the new character data (the URL changes but the page remains unchanged), because the fetch only happens via the `FetchDataOnMountWrapper` component's `componentDidMount` function, and this scenario is not a remount of the component.

To make this work, I have added handling in the `FetchDataOnMountWrapper` component's `componentWillReceiveProps` function that performs a data fetch based on the new location on the condition that the path has not changed (i.e. last and current is `/characters/:uuid`) but the specific URL has (i.e. from `/characters/1` to `/characters/2`).