### PR TITLE
Convert: Form headers + labels from camelCase to sentence case

### DIFF
--- a/src/lib/camel-case-to-sentence-case.js
+++ b/src/lib/camel-case-to-sentence-case.js
@@ -1,0 +1,4 @@
+export default camelCasedText =>
+	camelCasedText
+		.replace(/([A-Z])/g, match => ` ${match.toLowerCase()}`)
+		.replace(/^./, match => match.toUpperCase());

--- a/src/react/components/form.jsx
+++ b/src/react/components/form.jsx
@@ -4,6 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
+import camelCaseToSentenceCase from '../../lib/camel-case-to-sentence-case';
 import createBlankMap from '../../lib/create-blank-map';
 import mapHasNonEmptyString from '../../lib/map-has-non-empty-string';
 import { updateModel } from '../../redux/actions/model';
@@ -170,7 +171,7 @@ class Form extends React.Component {
 									key={`${statePath.join('-')}-${key}`}
 								>
 
-									<label className="fieldset__label">{key}:</label>
+									<label className="fieldset__label">{camelCaseToSentenceCase(key)}:</label>
 
 									{ handleValue(value, [...statePath, key]) }
 
@@ -192,7 +193,7 @@ class Form extends React.Component {
 						.map(key =>
 							<fieldset className="fieldset" key={key}>
 
-								<h2 className="fieldset__header">{key}:</h2>
+								<h2 className="fieldset__header">{camelCaseToSentenceCase(key)}:</h2>
 
 								{ handleValue(this.state[key], [key]) }
 


### PR DESCRIPTION
Converts camelCased attribute names into sentence case when using them as headers and labels in the form.

Sentence case example (i.e. first word is capitalised; subsequent words are in lowercase):

> The quick brown fox jumps over the lazy dog.

#### Before:
![before](https://user-images.githubusercontent.com/10484515/59164027-fe583d00-8aff-11e9-9a72-63fcb46ecc2d.png)

#### After:
![after](https://user-images.githubusercontent.com/10484515/59164029-044e1e00-8b00-11e9-95c6-b712056f9166.png)

#### References:
- [Stack Overflow: Convert camelCaseText to Sentence Case Text](https://stackoverflow.com/questions/7225407/convert-camelcasetext-to-sentence-case-text#answer-39718708).
- [Wikipedia: Letter case](https://en.wikipedia.org/wiki/Letter_case).