### PR TITLE
Use: async/await

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
     "fetch": false
   },
   "parserOptions": {
-      "sourceType": "module"
+      "sourceType": "module",
+      "ecmaVersion": 2017
   },
   "rules": {
     "eqeqeq": 2,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "https://github.com/andygout",
   "license": "MS-RSL",
   "dependencies": {
+    "core-js": "^3.1.4",
     "express": "^4.14.0",
     "express-handlebars": "^3.0.0",
     "express-session": "^1.14.1",
@@ -34,6 +35,7 @@
     "redux-immutable": "^4.0.0",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
+    "regenerator-runtime": "^0.13.2",
     "serve-favicon": "^2.2.0"
   },
   "devDependencies": {

--- a/src/redux/actions/model.js
+++ b/src/redux/actions/model.js
@@ -19,7 +19,7 @@ const requestUpdate = model =>
 const receiveUpdate = instance =>
 	createAction(actions[`RECEIVE_${instance.model.toUpperCase()}_UPDATE`], instance);
 
-export const fetchModel = (model, uuid = null) => dispatch => {
+export const fetchModel = (model, uuid = null) => async dispatch => {
 
 	const instance = uuid
 		? true
@@ -35,20 +35,25 @@ export const fetchModel = (model, uuid = null) => dispatch => {
 
 	if (instance) url += `/${uuid}/edit`;
 
-	return fetch(url, { mode: 'cors' })
-		.then(response => {
+	try {
 
-			if (response.status !== 200) throw new Error(response.statusText);
+		const response = await fetch(url, { mode: 'cors' });
 
-			return response.json();
+		if (response.status !== 200) throw new Error(response.statusText);
 
-		})
-		.then(instance => dispatch(receive(instance, model)))
-		.catch(({ message }) => dispatch(setError({ exists: true, message })));
+		const instance = await response.json();
+
+		dispatch(receive(instance, model))
+
+	} catch ({ message }) {
+
+		dispatch(setError({ exists: true, message }));
+
+	}
 
 }
 
-export const updateModel = instance => dispatch => {
+export const updateModel = instance => async dispatch => {
 
 	dispatch(requestUpdate(instance.model));
 
@@ -63,15 +68,20 @@ export const updateModel = instance => dispatch => {
 		body: JSON.stringify(instance)
 	};
 
-	return fetch(url, initObject)
-		.then(response => {
+	try {
 
-			if (response.status !== 200) throw new Error(response.statusText);
+		const response = await fetch(url, initObject);
 
-			return response.json();
+		if (response.status !== 200) throw new Error(response.statusText);
 
-		})
-		.then(instance => dispatch(receiveUpdate(instance)))
-		.catch(({ message }) => dispatch(setError({ exists: true, message })));
+		const instance = await response.json();
+
+		dispatch(receiveUpdate(instance));
+
+	} catch ({ message }) {
+
+		dispatch(setError({ exists: true, message }));
+
+	}
 
 }

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -3,6 +3,9 @@
 	no-unused-vars: ["error", { "argsIgnorePattern": "next" }]
 */
 
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import express from 'express';
 import exphbs from 'express-handlebars';
 import favicon from 'serve-favicon';
@@ -45,7 +48,7 @@ const store = createStore(
 	applyMiddleware(...[thunkMiddleware])
 );
 
-app.get('*', (req, res) => {
+app.get('*', async (req, res) => {
 
 	const { dispatch, getState } = store;
 
@@ -61,24 +64,22 @@ app.get('*', (req, res) => {
 
 	});
 
-	Promise.all(fetchDataPromises).then(() => {
+	await Promise.all(fetchDataPromises);
 
-		const preloadedState = getState();
+	const preloadedState = getState();
 
-		const reactHtml = getReactHtml(req, store);
+	const reactHtml = getReactHtml(req, store);
 
-		const head = Helmet.rewind();
+	const head = Helmet.rewind();
 
-		res.render(
-			'react-mount',
-			{
-				headTitleHtml: head.title.toString(),
-				clientData: JSON.stringify(preloadedState),
-				reactHtml
-			}
-		);
-
-	});
+	res.render(
+		'react-mount',
+		{
+			headTitleHtml: head.title.toString(),
+			clientData: JSON.stringify(preloadedState),
+			reactHtml
+		}
+	);
 
 });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,7 +72,17 @@ const clientConfig = {
 				test: /\.(js|jsx)$/,
 				loader: 'babel-loader',
 				query: {
-					presets: ['@babel/preset-env', '@babel/preset-react']
+					presets: [
+						[
+							"@babel/preset-env",
+							{
+								"targets": {
+									"node": "10"
+								}
+							}
+						],
+						'@babel/preset-react'
+					]
 				}
 			}
 		]


### PR DESCRIPTION
Applies ES2017 (ES8) `async/await` syntax for promise handling.

#### References:
- [Stack Overflow: Babel 6 regeneratorRuntime is not defined](https://stackoverflow.com/questions/33527653/babel-6-regeneratorruntime-is-not-defined#answer-33527883): "`babel-polyfill` is required".
- [Babel: @babel/polyfill](https://babeljs.io/docs/en/babel-polyfill): "As of Babel 7.4.0, this package has been deprecated in favor of directly including `core-js/stable` (to polyfill ECMAScript features) and `regenerator-runtime/runtime` (needed to use transpiled generator functions)".
- [GitHub: esline/eslint: Issues: Error with async: "Parsing error: Unexpected token =>"](https://github.com/eslint/eslint/issues/8126#issuecomment-281559970): "you should use `ecmaVersion: 8` or `ecmaVersion: 2017` in your config".
- [Medium: Enabling Async/Await and Generator Functions in Babel and Node JS by Binyamin](https://medium.com/@binyamin/enabling-async-await-and-generator-functions-in-babel-node-and-express-71e941b183e2): `.babelrc` changes required to prevent `Uncaught ReferenceError: regeneratorRuntime is not defined`.

#### New dependencies:
- [npm: core-js](https://www.npmjs.com/package/core-js).
- [npm: regenerator-runtime](https://www.npmjs.com/package/regenerator-runtime).