### PR TITLE
Add isomorphic-fetch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "express-handlebars": "^3.0.0",
     "express-session": "^1.14.1",
     "immutable": "4.0.0-rc.9",
+    "isomorphic-fetch": "^2.2.1",
     "morgan": "^1.5.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",


### PR DESCRIPTION
`$ npm run build` currently produces this error:
```
ERROR in multi isomorphic-fetch ./src/server/app.js
Module not found: Error: Can't resolve 'isomorphic-fetch' in '/Users/andy.gout/Documents/theatrebase-cms'
@ multi isomorphic-fetch ./src/server/app.js
```

And trying `$ npm start` following that build produces:
```
/Users/andy.gout/Documents/theatrebase-cms/built/main.js:3072
(function webpackMissingModule() { throw new Error("Cannot find module \"isomorphic-fetch\""); }());
                                   ^

Error: Cannot find module "isomorphic-fetch"
    at webpackMissingModule (/Users/andy.gout/Documents/theatrebase-cms/built/main.js:3072:42)
    at Object.<anonymous> (/Users/andy.gout/Documents/theatrebase-cms/built/main.js:3072:97)
    at __webpack_require__ (/Users/andy.gout/Documents/theatrebase-cms/built/main.js:20:30)
    at /Users/andy.gout/Documents/theatrebase-cms/built/main.js:66:18
    at Object.<anonymous> (/Users/andy.gout/Documents/theatrebase-cms/built/main.js:69:10)
    at Module._compile (internal/modules/cjs/loader.js:1158:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1178:10)
    at Module.load (internal/modules/cjs/loader.js:1002:32)
    at Function.Module._load (internal/modules/cjs/loader.js:901:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)
[nodemon] app crashed - waiting for file changes before starting...
```

Adding `isomorphic-fetch` as a dependency fixes the error. Not sure how it worked before. 🤷‍♂️

#### New dependencies:
- [npm: isomorphic-fetch](https://www.npmjs.com/package/isomorphic-fetch).