### PR TITLE
Stop nodemon watching node_modules

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,7 +1,6 @@
 {
   "ignoreRoot": [],
   "watch": [
-    "node_modules",
     "src"
   ],
   "ext": "js jsx"


### PR DESCRIPTION
The below issue was encountered in `theatrebase-frontend` (and fixed in this equivalent PR: https://github.com/andygout/theatrebase-frontend/pull/24).

The same change is being made in this repo to prevent encountering the same issue.

> This error has started to display whenever running locally:

```
[nodemon] Internal watch failed: EMFILE: too many open files, watch '/Users/andy.gout/Documents/theatrebase-frontend/node_modules/fbjs/node_modules/core-js/modules/es6.object.is-extensible.js'
```

> (The exact node module included in the error message varies between occurrences.)

> There is no real need for nodemon to watch the node modules so this PR removes it from the watched directories.