### PR TITLE
Update React component lifecycles

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "immutable": "4.0.0-rc.9",
     "isomorphic-fetch": "^2.2.1",
     "morgan": "^1.5.1",
-    "react": "^16.2.0",
+    "react": "^16.13.1",
     "react-dom": "^16.2.0",
     "react-helmet": "^5.2.0",
     "react-immutable-proptypes": "^2.1.0",

--- a/src/react/utils/FetchDataOnMountWrapper.jsx
+++ b/src/react/utils/FetchDataOnMountWrapper.jsx
@@ -7,6 +7,21 @@ import { ErrorMessage, Footer, Header, Nav } from '../components';
 
 class FetchDataOnMountWrapper extends React.Component {
 
+	constructor (props) {
+
+		super(props);
+
+		const { match: { path, url } } = props;
+
+		this.state = {
+			match: {
+				path,
+				url
+			}
+		};
+
+	}
+
 	componentDidMount () {
 
 		const { fetchData, dispatch, match, location } = this.props;
@@ -15,19 +30,28 @@ class FetchDataOnMountWrapper extends React.Component {
 
 	};
 
-	componentWillReceiveProps (nextProps) {
+	static getDerivedStateFromProps (props, state) {
 
 		const fetchRequired =
-			(this.props.match.path === nextProps.match.path) &&
-			(this.props.match.url !== nextProps.match.url);
+			(state.match.path === props.match.path) &&
+			(state.match.url !== props.match.url);
 
 		if (fetchRequired) {
 
-			const { fetchData, dispatch, match, location } = nextProps;
+			const { fetchData, dispatch, match: { path, url }, location } = props;
 
 			fetchData.map(fetchDataFunction => fetchDataFunction(dispatch, match, location));
 
+			return {
+				match: {
+					path,
+					url
+				}
+			};
+
 		}
+
+		return null;
 
 	}
 


### PR DESCRIPTION
React is currently outputting the following warnings:

```
Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move code with side effects to componentDidMount, and set initial state in the constructor.
* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: BrowserRouter, Route, Router, SideEffect(NullComponent), Switch
```

```
Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: Route, Router, Switch
```

In line with the docs referenced by the warning, React has been upgraded and the usage of `componentWillReceiveProps` has been migrated to the new static method `getDerivedStateFromProps`.

#### References:
- [React: Update on Async Rendering by Brian Vaughn](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
  - [Updating `state` based on `props`](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props).