### PR TITLE
Upgrade react-helmet ^5.2.1 -> ^6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "morgan": "^1.5.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-helmet": "^5.2.1",
+    "react-helmet": "^6.0.0",
     "react-immutable-proptypes": "^2.2.0",
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.1.2",


### PR DESCRIPTION
Fixes issue described in https://github.com/andygout/theatrebase-cms/pull/43, which can be applied now that `react-helmet` has released v6 (which upgrades the version of its `react-side-effect` dependency to v2):

> Now the only remaining error is (N.B. server logs provided, although error also appears in console logs):

```
Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move code from componentWillMount to componentDidMount (preferred in most cases) or the constructor.

Please update the following components: SideEffect(NullComponent)
    in SideEffect(NullComponent)
    in HelmetWrapper
    in div
    in FetchDataOnMountWrapper
    …
```

> This is dependent on `react-helmet` releasing a version that upgrades its `react-side-effect` dependency to v2.0.0, as described in [this issue](https://github.com/bbc/simorgh/issues/3893), which as of writing is still in beta.