### PR TITLE
Rename app element id + class

### DIFF
--- a/src/client/stylesheets/_page.scss
+++ b/src/client/stylesheets/_page.scss
@@ -26,7 +26,7 @@ a {
 	}
 }
 
-.app {
+.page-container {
 	display: flex;
 	flex: auto;
 	margin: 0 auto;

--- a/src/react/client-mount.jsx
+++ b/src/react/client-mount.jsx
@@ -29,7 +29,7 @@ window.onload = () => {
 				<App />
 			</BrowserRouter>
 		</Provider>,
-		document.getElementById('app')
+		document.getElementById('page-container')
 	);
 
 };

--- a/views/react-mount.html
+++ b/views/react-mount.html
@@ -1,2 +1,2 @@
 <script id="react-client-data" type="text/json">{{{clientData}}}</script>
-<div id="app" class="app">{{{reactHtml}}}</div>
+<div id="page-container" class="page-container">{{{reactHtml}}}</div>


### PR DESCRIPTION
`app` is a bit too broad for what purpose this element serves, and so the more specific name of `page-container` is now used.