### PR TITLE
Show delete button for existing instances only

### DIFF
--- a/src/react/components/form/Form.jsx
+++ b/src/react/components/form/Form.jsx
@@ -139,6 +139,8 @@ class Form extends React.Component {
 			? capitalise(this.props.action)
 			: 'Submit';
 
+		const isDeleteButtonRequired = this.props.action === FORM_ACTIONS.update;
+
 		const handleValue = (value, statePath, errors) =>
 			Map.isMap(value)
 				? renderAsForm(value, statePath)
@@ -235,8 +237,12 @@ class Form extends React.Component {
 				}
 
 				<input className="button" type="submit" value={submitButtonText} />
-				<input className="button" onClick={this.handleDelete} value={'Delete'} readOnly={true} />
 
+				{
+					isDeleteButtonRequired && (
+						<input className="button" onClick={this.handleDelete} value={'Delete'} readOnly={true} />
+					)
+				}
 			</form>
 		);
 


### PR DESCRIPTION
Only show delete button when form's action is **update** rather than **create**, i.e. when an instance exists.