### PR TITLE
Use button tags (rather than input tags with 'type=submit')

### DIFF
--- a/src/client/stylesheets/_form.scss
+++ b/src/client/stylesheets/_form.scss
@@ -75,7 +75,4 @@ $removal-button-border-width: 1px;
 	width: 170px;
 	background-color: $button-background-color;
 	cursor: pointer;
-	text-align: center;
-	box-sizing: border-box;
-	border-style: outset;
 }

--- a/src/react/components/form/Form.jsx
+++ b/src/react/components/form/Form.jsx
@@ -125,6 +125,8 @@ class Form extends React.Component {
 
 	handleDelete () {
 
+		event.preventDefault();
+
 		this.props.deleteInstance(this.state);
 
 	};
@@ -236,11 +238,11 @@ class Form extends React.Component {
 						)
 				}
 
-				<input className="button" type="submit" value={submitButtonText} />
+				<button className="button">{ submitButtonText }</button>
 
 				{
 					isDeleteButtonRequired && (
-						<input className="button" onClick={this.handleDelete} value={'Delete'} readOnly={true} />
+						<button className="button" onClick={this.handleDelete}>Delete</button>
 					)
 				}
 			</form>


### PR DESCRIPTION
> From my understanding at a pretty basic level the <button> will automatically submit, which can cause problems if you want to use a button in a form without it submitting. So it might be better to use <input type="button"> or <button type="button">. Without a type, button automatically receives a type of submit.

Myles2 in https://forum.freecodecamp.org/t/what-is-the-difference-between-button-and-input-type-button/253223#post_3.

Because the delete button now has an inherent type of `submit`, the `handleDelete()` method requires an `event.preventDefault();` else it will result in the form in being submitted, which is not desired for the delete action.

An alternate is to explicitly set a `type="button"` for the delete button (to override the inherent `type="submit"`), but it won't be obvious why this is the case for the delete button, but not the submit (create/update) button, and so the approach that applies most consistency to the two buttons seems the best approach.

Some styles applied in PR https://github.com/andygout/theatrebase-cms/pull/67 can also be removed as they were only required to give the delete button the same styling as applied to the submit (create/update) button, which received certain default styles through being an `input` tag with `type="submit"` (the delete button was an `input` tag but did not have `type="submit"`).

### References:
- [freeCodeCamp: What is the difference between \<button\> and \<input type=“button”\>](https://forum.freecodecamp.org/t/what-is-the-difference-between-button-and-input-type-button/253223).