### PR TITLE
Remove redirectPath from state after redirect has occurred

### DIFF
--- a/src/react/components/form/Form.jsx
+++ b/src/react/components/form/Form.jsx
@@ -133,7 +133,20 @@ class Form extends React.Component {
 
 	render () {
 
-		if (this.props.redirectPath) return <Redirect to={this.props.redirectPath} />;
+		if (this.props.redirectPath) {
+
+			const redirectToProps = {
+				pathname: this.props.redirectPath,
+				state: {
+					redirectPathOriginStateProp: `${this.state.model}FormData`
+				}
+			};
+
+			return (
+				<Redirect to={redirectToProps} />
+			);
+
+		}
 
 		const concealedKeys = ['model', 'uuid', 'errors', 'hasErrors'];
 

--- a/src/react/utils/FetchDataOnMountWrapper.jsx
+++ b/src/react/utils/FetchDataOnMountWrapper.jsx
@@ -4,6 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
 import { ErrorMessage, Footer, Header, Navigation, Notification } from '../components';
+import { removeRedirectPath } from '../../redux/actions/model';
 
 class FetchDataOnMountWrapper extends React.Component {
 
@@ -12,6 +13,9 @@ class FetchDataOnMountWrapper extends React.Component {
 		const { fetchData, dispatch, match, location } = this.props;
 
 		if (fetchData) fetchData.map(fetchDataFunction => fetchDataFunction(dispatch, match, location));
+
+		if (location.state && location.state.redirectPathOriginStateProp)
+			dispatch(removeRedirectPath(location.state.redirectPathOriginStateProp));
 
 	};
 

--- a/src/redux/actions/model.js
+++ b/src/redux/actions/model.js
@@ -281,11 +281,20 @@ const deleteInstance = instance => async dispatch => {
 
 }
 
+const removeRedirectPath = redirectPathOriginStateProp => async (dispatch, getState) => {
+
+	const { instance } = getState().get(redirectPathOriginStateProp).toJS();
+
+	dispatch(receiveEditFormData({ instance }));
+
+}
+
 export {
 	fetchList,
 	fetchInstanceTemplate,
 	fetchInstance,
 	createInstance,
 	updateInstance,
-	deleteInstance
+	deleteInstance,
+	removeRedirectPath
 }


### PR DESCRIPTION
The app is currently experiencing the following issue, created via these steps:

- Delete a theatre instance.
- This triggers a redirect to the Theatres list page.
- Visit Production list page via navigation link.
- Click 'New theatre' link.
- Displays Theatres list page (desired behaviour is 'New theatre' page).

This is caused by the `Form` component mapping its props to the `theatreFormData` Redux state.

When clicking the 'New theatre' link, the app renders the Form component (required for the 'New theatre' page) using the existing `theatreFormData` from the Redux state while it waits for the new theatre form data to be fetched.

However, the existing `theatreFormData` data still includes the `redirectPath` value (pointing to the Theatres list page), which gets triggered upon render of the Form component, and so the overall result of this action is that the Theatres list page gets displayed.

To overcome this, arguments are provided to the Redirect component that detail which property in the Redux state caused the redirect (`theatreFormData` in this example). Then when the destination page of the redirect mounts (re. `FetchDataOnMountWrapper` component's `componentDidMount()` method), it receives those props given to the Redirect component and can use them to determine if that page has been accessed as a result of a redirect.

If that is the case then it resets the form data for the applicable model from which the redirect originated (it resets it with the existing state except for the `redirectPath` property), meaning the next time the Form component is mounted there will be no redirect.