### PR TITLE
Display notification for instance delete failure

### DIFF
--- a/src/redux/actions/model.js
+++ b/src/redux/actions/model.js
@@ -259,19 +259,33 @@ const deleteInstance = instance => async dispatch => {
 
 		const fetchedInstance = await performFetch(url, fetchSettings);
 
-		dispatch(receiveDelete(fetchedInstance));
+		if (fetchedInstance.hasErrors) {
 
-		const redirectPath = `/${pluralise(fetchedInstance.model)}`;
+			const notification = {
+				text: `This ${fetchedInstance.model} cannot be deleted because it has dependent associations`,
+				status: NOTIFICATION_STATUSES.failure,
+				isActive: true
+			};
 
-		dispatch(receiveEditFormData({ instance: fetchedInstance, redirectPath }));
+			dispatch(activateNotification(notification));
 
-		const notification = {
-			text: `${fetchedInstance.name} (${fetchedInstance.model}) has been deleted`,
-			status: NOTIFICATION_STATUSES.success,
-			isActive: true
-		};
+		} else {
 
-		dispatch(activateNotification(notification));
+			dispatch(receiveDelete(fetchedInstance));
+
+			const redirectPath = `/${pluralise(fetchedInstance.model)}`;
+
+			dispatch(receiveEditFormData({ instance: fetchedInstance, redirectPath }));
+
+			const notification = {
+				text: `${fetchedInstance.name} (${fetchedInstance.model}) has been deleted`,
+				status: NOTIFICATION_STATUSES.success,
+				isActive: true
+			};
+
+			dispatch(activateNotification(notification));
+
+		}
 
 	} catch ({ message }) {
 


### PR DESCRIPTION
Dependent on PR: https://github.com/andygout/theatrebase-api/pull/156.

The response from the API for a failed delete request (owing to the existence of dependent associations) looks like:

```json
{
    "name": "National Theatre",
    "errors": {
        "associations": [
            "productions"
        ]
    },
    "model": "theatre",
    "uuid": "c6e3cb0a-4223-44cd-a55e-ac6b737c9c40",
    "hasErrors": true
}
```

This PR adds logic to the Redux action to maintain the edit page for the instance and display a suitable notification:

![delete-failure-notification](https://user-images.githubusercontent.com/10484515/87856951-aacb3c00-c91a-11ea-947d-6d8e1ae5f87d.png)

A future PR will incorporate the data included in `errors.associations`.