### PR TITLE
Apply additional styling to notification

### DIFF
--- a/src/client/stylesheets/_notification.scss
+++ b/src/client/stylesheets/_notification.scss
@@ -2,7 +2,9 @@
 	position: fixed;
 	top: 10px;
 	right: 10px;
+	margin-left: 10px;
 	padding: 20px;
+	max-width: 500px;
 	border-radius: 5px;
 	border: 2px solid $border-color;
 }


### PR DESCRIPTION
Some additional styling to prevent the notification from becoming too wide and also ensure that it is not flush against the left-hand side of the viewport when the viewport is narrower.