### PR TITLE
Rename associations to dependentAssociations

### DIFF
--- a/src/redux/actions/model.js
+++ b/src/redux/actions/model.js
@@ -263,12 +263,12 @@ const deleteInstance = instance => async dispatch => {
 
 		if (fetchedInstance.hasErrors) {
 
-			const dependentAssociations = fetchedInstance.errors.associations.join(', ');
+			const { dependentAssociations } = fetchedInstance.errors;
 
 			notification = {
 				text: `This ${fetchedInstance.model} cannot be deleted because
 					it has dependent associations with instances
-					of the following models: ${dependentAssociations}`
+					of the following models: ${dependentAssociations.join(', ')}`
 				,
 				status: NOTIFICATION_STATUSES.failure,
 				isActive: true


### PR DESCRIPTION
Dependent on PR: https://github.com/andygout/theatrebase-api/pull/157.

Other instances with associations can be deleted, so this PR renames `associations` to `dependentAssociations` to make clear the specific nature of the associations that prevent a delete from occurring.