### PR TITLE
Use object shorthand form of mapDispatchToProps

### DIFF
--- a/src/react/components/form/Form.jsx
+++ b/src/react/components/form/Form.jsx
@@ -265,7 +265,4 @@ class Form extends React.Component {
 
 };
 
-const mapDispatchToProps = dispatch =>
-	bindActionCreators({ createInstance, updateInstance, deleteInstance }, dispatch);
-
-export default connect(null, mapDispatchToProps)(Form);
+export default connect(null, { createInstance, updateInstance, deleteInstance })(Form);


### PR DESCRIPTION
From the below link:

```jsx
// React Redux does this for you automatically:
dispatch => bindActionCreators(mapDispatchToProps, dispatch)
```

> Therefore, our `mapDispatchToProps` can simply be:
```jsx 
const mapDispatchToProps = {
  increment,
  decrement,
  reset
}
```

> Since the actual name of the variable is up to you, you might want to give it a name like `actionCreators`, or even define the object inline in the call to `connect`:
```jsx
import {increment, decrement, reset} from "./counterActions";

// either
const actionCreators = {
  increment,
  decrement,
  reset
}

export default connect(mapState, actionCreators)(Counter);

// or
export default connect(
  mapState,
  { increment, decrement, reset }
)(Counter);
```

### References:
- [React Redux - Connect: Dispatching Actions with `mapDispatchToProps` - Defining `mapDispatchToProps` As An Object](https://react-redux.js.org/using-react-redux/connect-mapdispatch#defining-mapdispatchtoprops-as-an-object).