### PR TITLE
Make all propTypes isRequired

### DIFF
--- a/src/react/components/ContentHeader.jsx
+++ b/src/react/components/ContentHeader.jsx
@@ -6,19 +6,15 @@ const ContentHeader = props => {
 	const { text } = props;
 
 	return (
-		text
-			? (
-				<div className="content-header">
-					{ text }
-				</div>
-			)
-			: null
+		<div className="content-header">
+			{ text }
+		</div>
 	);
 
 };
 
 ContentHeader.propTypes = {
-	text: PropTypes.string
+	text: PropTypes.string.isRequired
 };
 
 export default ContentHeader;

--- a/src/react/components/InstanceDocumentTitle.jsx
+++ b/src/react/components/InstanceDocumentTitle.jsx
@@ -32,9 +32,9 @@ const InstanceDocumentTitle = props => {
 };
 
 InstanceDocumentTitle.propTypes = {
-	name: PropTypes.string,
-	model: PropTypes.string,
-	formAction: PropTypes.string
+	name: PropTypes.string.isRequired,
+	model: PropTypes.string.isRequired,
+	formAction: PropTypes.string.isRequired
 };
 
 export default InstanceDocumentTitle;

--- a/src/react/components/Notification.jsx
+++ b/src/react/components/Notification.jsx
@@ -24,7 +24,7 @@ const Notification = props => {
 
 Notification.propTypes = {
 	text: PropTypes.string.isRequired,
-	status: PropTypes.string
+	status: PropTypes.string.isRequired
 };
 
 export default Notification;

--- a/src/react/components/form/Form.jsx
+++ b/src/react/components/form/Form.jsx
@@ -19,9 +19,7 @@ class Form extends React.Component {
 
 		super(props);
 
-		this.state = props.instance
-			? this.createObjectWithImmutableContent(props.instance)
-			: {};
+		this.state = this.createObjectWithImmutableContent(props.instance);
 
 		this.handleSubmit = this.handleSubmit.bind(this);
 		this.handleDelete = this.handleDelete.bind(this);
@@ -150,9 +148,7 @@ class Form extends React.Component {
 
 		const concealedKeys = ['model', 'uuid', 'errors', 'hasErrors'];
 
-		const submitButtonText = this.props.action
-			? capitalise(this.props.action)
-			: 'Submit';
+		const submitButtonText = capitalise(this.props.action);
 
 		const isDeleteButtonRequired = this.props.action === FORM_ACTIONS.update;
 
@@ -170,10 +166,14 @@ class Form extends React.Component {
 								hasErrors={!!errors}
 								handleChange={this.handleChange.bind(this, statePath)}
 							/>
-							<InputErrors
-								errors={errors}
-								statePath={statePath}
-							/>
+							{
+								!!errors && (
+									<InputErrors
+										errors={errors}
+										statePath={statePath}
+									/>
+								)
+							}
 						</React.Fragment>
 					);
 
@@ -266,8 +266,8 @@ class Form extends React.Component {
 }
 
 Form.propTypes = {
-	instance: ImmutablePropTypes.map,
-	action: PropTypes.string,
+	instance: ImmutablePropTypes.map.isRequired,
+	action: PropTypes.string.isRequired,
 	redirectPath: PropTypes.string,
 	createInstance: PropTypes.func.isRequired,
 	updateInstance: PropTypes.func.isRequired,

--- a/src/react/components/form/InputErrors.jsx
+++ b/src/react/components/form/InputErrors.jsx
@@ -7,7 +7,7 @@ const InputErrors = props => {
 	const { errors, statePath } = props;
 
 	return (
-		!!errors && errors.map(errorText =>
+		errors.map(errorText =>
 			<ul key={`${statePath.join('-')}-error`}>
 
 				<li className="field__error-list-item">{ errorText }</li>
@@ -19,8 +19,8 @@ const InputErrors = props => {
 };
 
 InputErrors.propTypes = {
-	errors: ImmutablePropTypes.list,
-	statePath: PropTypes.array
+	errors: ImmutablePropTypes.list.isRequired,
+	statePath: PropTypes.array.isRequired
 };
 
 export default InputErrors;

--- a/src/react/utils/InstanceWrapper.jsx
+++ b/src/react/utils/InstanceWrapper.jsx
@@ -1,3 +1,4 @@
+import { Map } from 'immutable';
 import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
@@ -22,12 +23,12 @@ class InstanceWrapper extends React.Component {
 			<React.Fragment>
 
 				<InstanceDocumentTitle
-					name={instance.get('name')}
-					model={instance.get('model')}
-					formAction={formData.get('action')}
+					name={instance.get('name', '')}
+					model={instance.get('model', '')}
+					formAction={formData.get('action', '')}
 				/>
 
-				<ContentHeader text={instance.get('model')} />
+				<ContentHeader text={instance.get('model', '')} />
 
 				<InstancePageTitle
 					name={instance.get('name')}
@@ -38,8 +39,8 @@ class InstanceWrapper extends React.Component {
 				<FormattedJson data={instance} />
 
 				<Form
-					instance={formData.get('instance')}
-					action={formData.get('action')}
+					instance={formData.get('instance', Map({}))}
+					action={formData.get('action', 'Submit')}
 					redirectPath={formData.get('redirectPath')}
 				/>
 


### PR DESCRIPTION
The only exceptions are the following:

- Form component `redirectPath` prop: its presence triggers a redirect so its `undefined` status is required to avoid unnecessary redirects.
- PageTitle component `isNewInstance` prop: this is only applied via the `withInstancePageTitle` HOC (Higher-Order Component) and does not make sense in the context of other pages (e.g. Home, ErrorPage, ListWrapper) where its absence will help avoid confusion.