### PR TITLE
Rename ContentHeader component -> InstanceLabel

### DIFF
--- a/src/client/stylesheets/_instance.scss
+++ b/src/client/stylesheets/_instance.scss
@@ -1,4 +1,4 @@
-.content-header {
+.instance-label {
 	margin-bottom: 20px;
 	padding: 0 5px;
 	display: inline-block;

--- a/src/client/stylesheets/index.scss
+++ b/src/client/stylesheets/index.scss
@@ -2,10 +2,10 @@
 
 @import 'normalize';
 
-@import 'content';
 @import 'footer';
 @import 'form';
 @import 'header';
+@import 'instance';
 @import 'navigation';
 @import 'notification';
 @import 'page';

--- a/src/react/components/InstanceLabel.jsx
+++ b/src/react/components/InstanceLabel.jsx
@@ -1,20 +1,20 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const ContentHeader = props => {
+const InstanceLabel = props => {
 
 	const { text } = props;
 
 	return (
-		<div className="content-header">
+		<div className="instance-label">
 			{ text }
 		</div>
 	);
 
 };
 
-ContentHeader.propTypes = {
+InstanceLabel.propTypes = {
 	text: PropTypes.string.isRequired
 };
 
-export default ContentHeader;
+export default InstanceLabel;

--- a/src/react/components/index.js
+++ b/src/react/components/index.js
@@ -1,23 +1,23 @@
 import { Form } from './form';
-import ContentHeader from './ContentHeader';
 import ErrorMessage from './ErrorMessage';
 import Footer from './Footer';
 import FormattedJson from './FormattedJson';
 import Header from './Header';
 import InstanceDocumentTitle from './InstanceDocumentTitle';
+import InstanceLabel from './InstanceLabel';
 import Navigation from './Navigation';
 import Notification from './Notification';
 import PageTitle from './PageTitle';
 import withInstancePageTitle from './withInstancePageTitle';
 
 export {
-	ContentHeader,
 	ErrorMessage,
 	Footer,
 	Form,
 	FormattedJson,
 	Header,
 	InstanceDocumentTitle,
+	InstanceLabel,
 	Navigation,
 	Notification,
 	PageTitle,

--- a/src/react/utils/InstanceWrapper.jsx
+++ b/src/react/utils/InstanceWrapper.jsx
@@ -3,10 +3,10 @@ import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import {
-	ContentHeader,
 	Form,
 	FormattedJson,
 	InstanceDocumentTitle,
+	InstanceLabel,
 	PageTitle,
 	withInstancePageTitle
 } from '../components';
@@ -28,7 +28,7 @@ class InstanceWrapper extends React.Component {
 					formAction={formData.get('action', '')}
 				/>
 
-				<ContentHeader text={instance.get('model', '')} />
+				<InstanceLabel text={instance.get('model', '')} />
 
 				<InstancePageTitle
 					name={instance.get('name')}


### PR DESCRIPTION
To create naming consistency with equivalent component in `theatrebase-spa` and `theatrebase-ssr` repos.

- [`theatrebase-spa` InstanceLabel component](https://github.com/andygout/theatrebase-spa/blob/master/src/react/components/InstanceLabel.jsx).
- [`theatrebase-ssr` InstanceLabel component](https://github.com/andygout/theatrebase-ssr/blob/master/src/components/InstanceLabel.jsx).