### PR TITLE
Add event parameter to handleDelete() method

### DIFF
--- a/src/react/components/form/Form.jsx
+++ b/src/react/components/form/Form.jsx
@@ -121,7 +121,7 @@ class Form extends React.Component {
 
 	}
 
-	handleDelete () {
+	handleDelete (event) {
 
 		event.preventDefault();
 


### PR DESCRIPTION
It seems that within the `handleDelete()` method, the `event` on which `preventDefault()` is called comes from a wider scope than the context of the method, i.e. it is by coincidence rather than design that the correct event has its default prevented.

This PR adds `event` as a parameter to the `handleDelete()` method to give confidence that the right event is having its default behaviour prevented.

As per the below examples, the `event.preventDefault()` is clearly required to prevent the form submit action from firing (owing to the delete button's inherent type of `submit`), which was described in more detail in this PR's description: https://github.com/andygout/theatrebase-cms/pull/71.

#### `handleDelete()` has no `event` parameter and `event.preventDefault()` is present (i.e. current state of code)
- handleDelete event:  `MouseEvent {isTrusted: true, screenX: 525, screenY: 468, clientX: 525, clientY: 334, …}`

#### `handleDelete()` has no `event` parameter and `event.preventDefault()` is absent.
- handleDelete event:  `MouseEvent {isTrusted: true, screenX: 499, screenY: 472, clientX: 499, clientY: 338, …}`
- handleSubmit event:  `SyntheticEvent {dispatchConfig: {…}, _targetInst: FiberNode, nativeEvent: SubmitEvent, type: "submit", target: form.form, …}`

#### `handleDelete()` has `event` parameter and `event.preventDefault()` is absent.
- handleDelete event:  `Class {dispatchConfig: {…}, _targetInst: FiberNode, nativeEvent: MouseEvent, type: "click", target: button.button, …}`
- handleSubmit event:  `SyntheticEvent {dispatchConfig: {…}, _targetInst: FiberNode, nativeEvent: SubmitEvent, type: "submit", target: form.form, …}`

#### `handleDelete()` has `event` parameter and `event.preventDefault()` is present.
- handleDelete event:  `Class {dispatchConfig: {…}, _targetInst: FiberNode, nativeEvent: MouseEvent, type: "click", target: button.button, …}`
