### PR TITLE
Fix form creation of blank list item appendage where nested errors exist

### DIFF
--- a/src/lib/create-blank-map.js
+++ b/src/lib/create-blank-map.js
@@ -6,7 +6,11 @@ const createBlankMap = map => {
 		map.keySeq().forEach(key =>
 			mutableMap.update(key, value => {
 
-				if (Map.isMap(value)) {
+				if (key === 'errors') {
+
+					return Map();
+
+				} else if (Map.isMap(value)) {
 
 					return createBlankMap(value);
 


### PR DESCRIPTION
A bug exists in the form component:

- Go to the 'New production' form.
- Enter values for the role of a cast member that will result in an error, e.g. matching `name` and `characterName` values.
- Submit the form so that it will re-render with a "This production contains errors" notification.
- Try and enter text into the cast member `name` field.
- This will result in the below error message:

<img width="1440" alt="Screenshot 2020-08-08 at 21 27 08" src="https://user-images.githubusercontent.com/10484515/89719222-f1fa9900-d9bd-11ea-9747-b402f7cb16dc.png">

The error is arising from [this line](https://github.com/andygout/theatrebase-cms/blob/master/src/lib/create-blank-map.js#L5) in the `createBlankMap` function:
```js
return map.withMutations(mutableMap =>
```

This is caused by the list item being re-created as a blank map including the below segment, which will eventually be encountered by the code as it recurses over the Map.
```
errors: {
	characterName: ['Character name is only required if different from role name']
}
```

The function will determine that `['Character name is only required if different from role name']` is a list and then handle it with `return List([createBlankMap(value.get(0))]);`, which will provide the `createBlankMap` function with an argument of the string `'Character name is only required if different from role name'`, and so fail as per the error message when it tries to treat that value as an Map.

Ultimately, when creating a blank array item, we don't want it to include any errors from the item from which it is making a copy. Therefore the fix is to simply return a blank Map for the `errors` property.