### PR TITLE
Fix Form component creating unrequired list item appendage

### DIFF
--- a/src/lib/map-has-non-empty-string.js
+++ b/src/lib/map-has-non-empty-string.js
@@ -6,7 +6,9 @@ const isMapWithNonEmptyString = value => Map.isMap(value) && searchForNonEmptySt
 
 const searchForNonEmptyString = map => {
 
-	for (let value of map.valueSeq()) {
+	const mapToSearch = map.delete('model');
+
+	for (let value of mapToSearch.valueSeq()) {
 
 		if (isNonEmptyString(value)) return true;
 


### PR DESCRIPTION
A bug exists in the Form component. To replicate:

- Go to the 'New production' form.
- Enter some values into a list item, e.g. the name of a cast member, the name or characterName of a role, and it will append a blank item to the end of the list (i.e. there are now two items in the list).
- Leave the production name blank to ensure that the form re-renders with an error.
- Submit the form and see it re-render with a "This production contains errors" notification.
- Edit the text of the list item to which you originally entered some values.
- This results in appended another blank item to the end of the list (i.e. there are now three items in the list), which is unnecessary given there is already one blank item at the end of the array.

<img width="1440" alt="Screenshot 2020-08-09 at 14 12 10" src="https://user-images.githubusercontent.com/10484515/89732993-61b66580-da4a-11ea-9f5c-099fbb6ddd9d.png">

This is caused by the module that checks whether the last list item contains any non-empty strings (`map-has-non-empty-string.js`).

It will encounter (e.g.) `model: 'role'`, which it rightly deems is a non-empty string and that a blank item needs to be appended to the list.

This PR fixes this bug by amending the function to first delete the `model` property from the map before searching it for a non-empty string.

The reason this does not happen before form submission (i.e. entering text into the first list item only appends a single item, as intended) is because when the first item to be appended is created, it uses the `create-blank-map.js` module, which sets all string values as empty strings. Therefore (in the Form component's state) its `model` value is an empty string, and so when queried as to whether it contains any non-empty strings values (and whether to append a further item to the list), the answer is false. However, the fact that the  `model` value is an empty string is not an accurate representation of that item and so needs to be corrected in a future PR.