### PR TITLE
Revise map-has-non-empty-string module

### DIFF
--- a/src/lib/map-has-non-empty-string.js
+++ b/src/lib/map-has-non-empty-string.js
@@ -1,6 +1,6 @@
 import { List, Map } from 'immutable';
 
-const isNonEmptyString = value => typeof value === 'string' && value.length;
+const isNonEmptyString = value => typeof value === 'string' && !!value.length;
 
 const isMapWithNonEmptyString = value => Map.isMap(value) && searchForNonEmptyString(value);
 


### PR DESCRIPTION
The conditional in the `isNonEmptyString` function in the `map-has-non-empty-string.js` module currently returns a mixture of boolean and number values, i.e.
- `typeof value === 'string'` will return a boolean
- `value.length` will return a number

To ensure consistency, i.e. the return value of the function is always a boolean, this PR amends the check of the value's length to evaluate to a boolean rather than a number.