### PR TITLE
Pin eslint-plugin-react version to v7.20.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "css-loader": "^0.28.0",
     "eslint": "^7.5.0",
     "eslint-plugin-no-only-tests": "^2.4.0",
-    "eslint-plugin-react": "^7.20.3",
+    "eslint-plugin-react": "7.20.5",
     "favicons-webpack-plugin": "^3.0.1",
     "lintspaces-cli": "^0.6.0",
     "mini-css-extract-plugin": "^0.9.0",


### PR DESCRIPTION
v7.20.6 of `eslint-plugin-react` throws the below errors which seem unrelated to its [described release changes](https://github.com/yannickcr/eslint-plugin-react/commit/a43f70ac202dc4d28d18fbfccaf3279d2cf1d072).

```
/home/circleci/project/src/react/components/withInstancePageTitle.jsx
  6:44  error  Component definition is missing display name  react/display-name
  8:10  error  'name' is missing in props validation         react/prop-types
  8:16  error  'model' is missing in props validation        react/prop-types
  8:23  error  'formAction' is missing in props validation   react/prop-types
```

This PR pins the `eslint-plugin-react` version to v7.20.5.

### References:
- [GitHub - yannickcr/eslint-plugin-react - Issues: v7.20.6 has breaking changes for react/display-name](https://github.com/yannickcr/eslint-plugin-react/issues/2758).