### PR TITLE
Apply source maps server-side

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "unit-test": "mocha --require @babel/register test/**/*.test.js",
     "build": "webpack",
     "watch": "webpack --watch",
-    "start": "nodemon built/main.js"
+    "start": "nodemon --require source-map-support/register built/main.js"
   },
   "pre-commit": [
     "lint-check",
@@ -41,7 +41,8 @@
     "redux-immutable": "^4.0.0",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
-    "serve-favicon": "^2.2.0"
+    "serve-favicon": "^2.2.0",
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const serverConfig = {
 		path: path.join(__dirname, 'built'),
 		filename: 'main.js'
 	},
+	devtool: 'inline-source-map',
 	module: {
 		rules: [
 			{


### PR DESCRIPTION
Provides reference to source code (not transpiled code) when an error is logged in the server to allow for easier debugging.

#### Before:
```
(node:19438) UnhandledPromiseRejectionWarning: ReferenceError: cosnole is not defined
    at /Users/andy.gout/Documents/theatrebase-cms/built/main.js:241:3
    …
```

#### After:
```
(node:19401) UnhandledPromiseRejectionWarning: ReferenceError: cosnole is not defined
    at /Users/andy.gout/Documents/theatrebase-cms/built/webpack:/src/server/router.js:23:1
    …
```