### PR TITLE
Deactivate notification upon error

### DIFF
--- a/src/redux/actions/model.js
+++ b/src/redux/actions/model.js
@@ -2,7 +2,7 @@ import nodeFetch from 'node-fetch';
 
 import createAction from './base';
 import { receiveError } from './error';
-import { activateNotification } from './notification';
+import { activateNotification, deactivateNotification } from './notification';
 import * as actions from '../utils/model-action-names';
 import { pluralise } from '../../lib/strings';
 import { NOTIFICATION_STATUSES } from '../../utils/constants';
@@ -73,6 +73,8 @@ const fetchList = pluralisedModel => async dispatch => {
 
 		dispatch(receiveError({ isExistent: true, message }));
 
+		dispatch(deactivateNotification());
+
 	}
 
 };
@@ -94,6 +96,8 @@ const fetchInstanceTemplate = model => async dispatch => {
 	} catch ({ message }) {
 
 		dispatch(receiveError({ isExistent: true, message }));
+
+		dispatch(deactivateNotification());
 
 	}
 
@@ -154,6 +158,8 @@ const createInstance = instance => async dispatch => {
 
 		dispatch(receiveError({ isExistent: true, message }));
 
+		dispatch(deactivateNotification());
+
 	}
 
 };
@@ -182,6 +188,8 @@ const fetchInstance = (model, uuid = null) => async dispatch => {
 	} catch ({ message }) {
 
 		dispatch(receiveError({ isExistent: true, message }));
+
+		dispatch(deactivateNotification());
 
 	}
 
@@ -237,6 +245,8 @@ const updateInstance = instance => async dispatch => {
 	} catch ({ message }) {
 
 		dispatch(receiveError({ isExistent: true, message }));
+
+		dispatch(deactivateNotification());
 
 	}
 
@@ -295,6 +305,8 @@ const deleteInstance = instance => async dispatch => {
 	} catch ({ message }) {
 
 		dispatch(receiveError({ isExistent: true, message }));
+
+		dispatch(deactivateNotification());
 
 	}
 


### PR DESCRIPTION
If an error is encountered when making a request to the API and an error page is displayed, there should be no notifications still present in that scenario as they are either meaningless or misleadingly inaccurate.

#### Before:
(The production had been updated once, but on the attempt to update the production a second time, the API request failed. The remaining presence of the notification from the first successful update inaccurately and misleadingly suggests that the second attempt was also successful.)
![before](https://user-images.githubusercontent.com/10484515/90319139-45746600-df2d-11ea-9b10-2d451ee3ef5b.png)

#### After:
![after](https://user-images.githubusercontent.com/10484515/90319143-4a391a00-df2d-11ea-899e-784776bc8020.png)