### PR TITLE
Prune instance JSON displayed on edit page

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "nodemon": "^1.11.0",
     "pre-commit": "^1.2.2",
     "sass-loader": "^6.0.3",
+    "sinon": "^9.0.3",
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11",
     "webpack-node-externals": "^1.7.2"

--- a/src/lib/is-object-with-keys.js
+++ b/src/lib/is-object-with-keys.js
@@ -1,0 +1,4 @@
+export const isObjectWithKeys = value =>
+	Object(value) === value &&
+	!Array.isArray(value) &&
+	Object.keys(value).length > 0;

--- a/src/lib/prune-instance.js
+++ b/src/lib/prune-instance.js
@@ -1,0 +1,41 @@
+import { isObjectWithKeys } from './is-object-with-keys';
+import { FORM_CONCEALED_KEYS } from '../utils/constants';
+
+const pruneInstance = (instance, recursions = 0) => {
+
+	return Object.keys(instance).reduce((accumulator, key) => {
+
+		if (recursions === 0 && key === 'model') {
+
+			accumulator[key] = instance[key];
+
+			return accumulator;
+
+		}
+
+		if (FORM_CONCEALED_KEYS.includes(key)) return accumulator;
+
+		if (isObjectWithKeys(instance[key])) {
+
+			accumulator[key] = pruneInstance(instance[key], recursions + 1);
+
+		} else if (Array.isArray(instance[key])) {
+
+			accumulator[key] =
+				instance[key]
+					.filter((item, index) => index === 0 || !!item.name.length)
+					.map(item => isObjectWithKeys(item) ? pruneInstance(item, recursions + 1) : item);
+
+		} else {
+
+			accumulator[key] = instance[key];
+
+		}
+
+		return accumulator;
+
+	}, {});
+
+};
+
+export default pruneInstance;

--- a/src/redux/actions/model.js
+++ b/src/redux/actions/model.js
@@ -4,6 +4,7 @@ import createAction from './base';
 import { receiveError } from './error';
 import { activateNotification, deactivateNotification } from './notification';
 import * as actions from '../utils/model-action-names';
+import pruneInstance from '../../lib/prune-instance';
 import { pluralise } from '../../lib/strings';
 import { NOTIFICATION_STATUSES } from '../../utils/constants';
 
@@ -89,7 +90,9 @@ const fetchInstanceTemplate = model => async dispatch => {
 
 		const fetchedInstance = await performFetch(url, { mode: 'cors' });
 
-		dispatch(receiveInstance(fetchedInstance));
+		const prunedInstance = pruneInstance(fetchedInstance);
+
+		dispatch(receiveInstance(prunedInstance));
 
 		dispatch(receiveNewFormData({ instance: fetchedInstance }));
 
@@ -138,7 +141,9 @@ const createInstance = instance => async dispatch => {
 
 		} else {
 
-			dispatch(receiveCreate(fetchedInstance));
+			const prunedInstance = pruneInstance(fetchedInstance);
+
+			dispatch(receiveCreate(prunedInstance));
 
 			const redirectPath = `/${pluralise(fetchedInstance.model)}/${fetchedInstance.uuid}`;
 
@@ -181,7 +186,9 @@ const fetchInstance = (model, uuid = null) => async dispatch => {
 
 		const fetchedInstance = await performFetch(url, { mode: 'cors' });
 
-		dispatch(receiveInstance(fetchedInstance));
+		const prunedInstance = pruneInstance(fetchedInstance);
+
+		dispatch(receiveInstance(prunedInstance));
 
 		dispatch(receiveEditFormData({ instance: fetchedInstance }));
 
@@ -228,7 +235,9 @@ const updateInstance = instance => async dispatch => {
 
 		} else {
 
-			dispatch(receiveUpdate(fetchedInstance));
+			const prunedInstance = pruneInstance(fetchedInstance);
+
+			dispatch(receiveUpdate(prunedInstance));
 
 			notification = {
 				text: `${fetchedInstance.name} (${fetchedInstance.model}) has been updated`,
@@ -286,7 +295,9 @@ const deleteInstance = instance => async dispatch => {
 
 		} else {
 
-			dispatch(receiveDelete(fetchedInstance));
+			const prunedInstance = pruneInstance(fetchedInstance);
+
+			dispatch(receiveDelete(prunedInstance));
 
 			const redirectPath = `/${pluralise(fetchedInstance.model)}`;
 

--- a/test/src/lib/is-object-with-keys.test.js
+++ b/test/src/lib/is-object-with-keys.test.js
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+
+import { isObjectWithKeys } from '../../../src/lib/is-object-with-keys';
+
+describe('Is Object With Keys module', () => {
+
+	it('considers object with keys as valid object', () => {
+
+		expect(isObjectWithKeys({ key: 'value' })).to.be.true;
+
+	});
+
+	it('will not consider null (which is type of object) as valid object', () => {
+
+		expect(isObjectWithKeys(null)).to.be.false;
+
+	});
+
+	it('will not consider empty array (which is type of object) as valid object', () => {
+
+		expect(isObjectWithKeys([])).to.be.false;
+
+	});
+
+	it('will not consider populated array (which is type of object) as valid object', () => {
+
+		expect(isObjectWithKeys([1, 2, 3])).to.be.false;
+
+	});
+
+	it('will not consider string type as valid object', () => {
+
+		expect(isObjectWithKeys('string')).to.be.false;
+
+	});
+
+	it('will not consider number type as valid object', () => {
+
+		expect(isObjectWithKeys(123)).to.be.false;
+
+	});
+
+	it('will not consider empty object (i.e. no keys) as valid object', () => {
+
+		expect(isObjectWithKeys({})).to.be.false;
+
+	});
+
+});

--- a/test/src/lib/prune-instance.test.js
+++ b/test/src/lib/prune-instance.test.js
@@ -1,0 +1,337 @@
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+
+import * as isObjectWithKeysModule from '../../../src/lib/is-object-with-keys';
+import pruneInstance from '../../../src/lib/prune-instance';
+
+describe('prune Instance module', () => {
+
+	let stubs;
+
+	const sandbox = createSandbox();
+
+	beforeEach(() => {
+
+		stubs = {
+			isObjectWithKeys: sandbox.stub(isObjectWithKeysModule, 'isObjectWithKeys').returns(false)
+		};
+
+	});
+
+	afterEach(() => {
+
+		sandbox.restore();
+
+	});
+
+	it('removes top-level concealed attributes (e.g. \'errors\', and \'uuid\')', () => {
+
+		const instance = {
+			name: 'King Lear',
+			errors: {},
+			uuid: 'b22157c0-4ecd-4bd9-b4fd-2656d3def80e'
+		};
+
+		const result = pruneInstance(instance);
+
+		const expectation = {
+			name: 'King Lear'
+		};
+
+		expect(stubs.isObjectWithKeys.calledOnce).to.be.true;
+		expect(result).to.deep.equal(expectation);
+
+	});
+
+	it('retains top-level \'model\' attribute', () => {
+
+		const instance = {
+			name: 'King Lear',
+			model: 'production'
+		};
+
+		const result = pruneInstance(instance);
+
+		const expectation = {
+			name: 'King Lear',
+			model: 'production'
+		};
+
+		expect(stubs.isObjectWithKeys.calledOnce).to.be.true;
+		expect(result).to.deep.equal(expectation);
+
+	});
+
+	it('removes nested-level concealed attributes (e.g. \'errors\', and \'model\')', () => {
+
+		stubs.isObjectWithKeys
+			.onFirstCall().returns(false)
+			.onSecondCall().returns(false)
+			.onThirdCall().returns(true)
+			.onCall(3).returns(false)
+			.onCall(4).returns(false)
+			.onCall(5).returns(true)
+			.onCall(6).returns(false)
+			.onCall(7).returns(false);
+
+		const instance = {
+			name: 'King Lear',
+			cast: [
+				{
+					name: 'Ian McKellen',
+					errors: {},
+					model: 'person',
+					roles: [
+						{
+							name: 'King Lear',
+							errors: {},
+							model: 'role',
+							characterName: ''
+						}
+					]
+				}
+			]
+		};
+
+		const result = pruneInstance(instance);
+
+		const expectation = {
+			name: 'King Lear',
+			cast: [
+				{
+					name: 'Ian McKellen',
+					roles: [
+						{
+							name: 'King Lear',
+							characterName: ''
+						}
+					]
+				}
+			]
+		};
+
+		expect(stubs.isObjectWithKeys.callCount).to.equal(8);
+		expect(result).to.deep.equal(expectation);
+
+	});
+
+	describe('filters out array items that have empty string name', () => {
+
+		context('array items with non-empty strings exist', () => {
+
+			it('filters out array items that have empty string name values', () => {
+
+				stubs.isObjectWithKeys
+					.onFirstCall().returns(false)
+					.onSecondCall().returns(false)
+					.onThirdCall().returns(true)
+					.onCall(3).returns(false)
+					.onCall(4).returns(false)
+					.onCall(5).returns(true)
+					.onCall(6).returns(false)
+					.onCall(7).returns(false);
+
+				const instance = {
+					name: 'King Lear',
+					cast: [
+						{
+							name: 'Ian McKellen',
+							roles: [
+								{
+									name: 'King Lear',
+									characterName: ''
+								},
+								{
+									name: '',
+									characterName: ''
+								}
+							]
+						},
+						{
+							name: '',
+							roles: [
+								{
+									name: '',
+									characterName: ''
+								}
+							]
+						}
+					]
+				};
+
+				const result = pruneInstance(instance);
+
+				const expectation = {
+					name: 'King Lear',
+					cast: [
+						{
+							name: 'Ian McKellen',
+							roles: [
+								{
+									name: 'King Lear',
+									characterName: ''
+								}
+							]
+						}
+					]
+				};
+
+				expect(stubs.isObjectWithKeys.callCount).to.equal(8);
+				expect(result).to.deep.equal(expectation);
+
+			});
+
+		});
+
+		context('array items with non-empty strings do not exist', () => {
+
+			it('leaves single array item that has empty string name value', () => {
+
+				stubs.isObjectWithKeys
+					.onFirstCall().returns(false)
+					.onSecondCall().returns(false)
+					.onThirdCall().returns(true)
+					.onCall(3).returns(false)
+					.onCall(4).returns(false)
+					.onCall(5).returns(true)
+					.onCall(6).returns(false)
+					.onCall(7).returns(false);
+
+				const instance = {
+					name: 'King Lear',
+					cast: [
+						{
+							name: '',
+							roles: [
+								{
+									name: '',
+									characterName: ''
+								}
+							]
+						}
+					]
+				};
+
+				const result = pruneInstance(instance);
+
+				const expectation = {
+					name: 'King Lear',
+					cast: [
+						{
+							name: '',
+							roles: [
+								{
+									name: '',
+									characterName: ''
+								}
+							]
+						}
+					]
+				};
+
+				expect(stubs.isObjectWithKeys.callCount).to.equal(8);
+				expect(result).to.deep.equal(expectation);
+
+			});
+
+		});
+
+	});
+
+	it('prunes a sample instance as per specification', () => {
+
+		stubs.isObjectWithKeys
+			.onFirstCall().returns(false)
+			.onSecondCall().returns(true)
+			.onThirdCall().returns(false)
+			.onCall(3).returns(true)
+			.onCall(4).returns(false)
+			.onCall(5).returns(false)
+			.onCall(6).returns(true)
+			.onCall(7).returns(false)
+			.onCall(8).returns(false)
+			.onCall(9).returns(true)
+			.onCall(10).returns(false)
+			.onCall(11).returns(false);
+
+		const instance = {
+			name: 'King Lear',
+			errors: {},
+			model: 'production',
+			uuid: 'b22157c0-4ecd-4bd9-b4fd-2656d3def80e',
+			theatre: {
+				name: 'Courtyard Theatre',
+				errors: {},
+				model: 'theatre'
+			},
+			playtext: {
+				name: '',
+				errors: {},
+				model: 'playtext'
+			},
+			cast: [
+				{
+					name: 'Ian McKellen',
+					errors: {},
+					model: 'person',
+					roles: [
+						{
+							name: 'King Lear',
+							errors: {},
+							model: 'role',
+							characterName: ''
+						},
+						{
+							name: '',
+							errors: {},
+							model: 'role',
+							characterName: ''
+						}
+					]
+				},
+				{
+					name: '',
+					errors: {},
+					model: 'person',
+					roles: [
+						{
+							name: '',
+							errors: {},
+							model: 'role',
+							characterName: ''
+						}
+					]
+				}
+			]
+		};
+
+		const result = pruneInstance(instance);
+
+		const expectation = {
+			name: 'King Lear',
+			model: 'production',
+			theatre: {
+				name: 'Courtyard Theatre'
+			},
+			playtext: {
+				name: ''
+			},
+			cast: [
+				{
+					name: 'Ian McKellen',
+					roles: [
+						{
+							name: 'King Lear',
+							characterName: ''
+						}
+					]
+				}
+			]
+		};
+
+		expect(stubs.isObjectWithKeys.callCount).to.equal(12);
+		expect(result).to.deep.equal(expectation);
+
+	});
+
+});


### PR DESCRIPTION
The edit page contains a JSON representation of the data used to populate the form.

The intention is that it serves as an illustration of what the instance looked like prior to edits being made in the form.

However, while a lot of information is required for the form, it is not particularly useful for the purpose that the JSON serves, and makes it a lot larger (and therefore harder to scan) than it needs to be.

This PR prunes the values that are not useful (although the top-level `model` property must remain as it  is used for the instance label, i.e. where it says 'PRODUCTION' above the 'King Lear' page title), as well as filtering out array items that have an empty string name value (except when they are the only array items so as to keep consistency with other top-level items, e.g. see in the below 'After' example how `playtext` is included, despite its empty string name value).

#### Before:
<img width="330" alt="before" src="https://user-images.githubusercontent.com/10484515/90339067-41f0e580-dfe6-11ea-8d48-830b2a2507ee.png">

#### After:
<img width="341" alt="after" src="https://user-images.githubusercontent.com/10484515/90339069-44533f80-dfe6-11ea-81ab-09d096733c59.png">