### PR TITLE
Scroll to top of page on notification

### DIFF
--- a/src/react/utils/FetchDataOnMountWrapper.jsx
+++ b/src/react/utils/FetchDataOnMountWrapper.jsx
@@ -5,6 +5,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
 import { ErrorMessage, Footer, Header, Navigation, Notification } from '../components';
+import ScrollToTop from './ScrollToTop';
 import { removeRedirectPath } from '../../redux/actions/model';
 
 class FetchDataOnMountWrapper extends React.Component {
@@ -38,6 +39,12 @@ class FetchDataOnMountWrapper extends React.Component {
 				<Navigation />
 
 				<main className="main-content">
+
+					{
+						notification.get('isActive') && (
+							<ScrollToTop />
+						)
+					}
 
 					{
 						notification.get('isActive') && (

--- a/src/react/utils/ScrollToTop.jsx
+++ b/src/react/utils/ScrollToTop.jsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+
+export default function ScrollToTop () {
+
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	});
+
+	return null;
+
+}


### PR DESCRIPTION
Currently, after an instance is created or updated using the form, the viewport stays in the same position (although after a successful create action the viewport's position can shift slightly owing to the (I am guessing) pathname change and increase in content, which can be slightly disorientating).

The changes in this PR will mean that the viewport now is set to the top of the screen after every event that creates a notification (both success and error), e.g. it will return to the top of the page after the form is submitted with content that returns with errors (which would ordinarily stay in the same position because the route has not changed).

This makes it a lot clearer that a form action has happened, which currently, even with the notification, is not always clear. It is especially unclear when a form with the same valid or invalid data is repeatedly submitted and the success/error notification remains the same (i.e. there is no clear indication that the form is actually being repeatedly submitted).

This change also, following a successful submission of the form, puts the viewport in a position that includes at least the top of the JSON representation of the newly-created/updated instance, which is a useful time to review it.

### References:
- [Stack Overflow: react-router scroll to top on every transition](https://stackoverflow.com/questions/36904185/react-router-scroll-to-top-on-every-transition).
- [React Router: Scroll Restoration](https://reactrouter.com/web/guides/scroll-restoration).