### PR TITLE
Apply ESLint comma-dangle rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
     }
   },
   "rules": {
+    "comma-dangle": 2,
     "eqeqeq": 2,
     "guard-for-in": 2,
     "new-cap": 0,

--- a/test/src/lib/create-blank-map.test.js
+++ b/test/src/lib/create-blank-map.test.js
@@ -98,7 +98,7 @@ describe('Create Blank Map module', () => {
 		it('converts strings to empty strings for top level attributes', () => {
 
 			const map = fromJS({
-				foo: 'string',
+				foo: 'string'
 			});
 
 			const result = createBlankMap(map);


### PR DESCRIPTION
Applies ESLint rule to prevent dangling commas.

### References:
- [ESLint: comma-dangle](https://eslint.org/docs/rules/comma-dangle)