### PR TITLE
Revise form to dictate output

### DIFF
--- a/src/lib/strings.js
+++ b/src/lib/strings.js
@@ -1,16 +1,10 @@
 import { IRREGULAR_PLURAL_NOUNS_MAP } from '../utils/constants';
 
-const camelCaseToSentenceCase = camelCasedText =>
-	camelCasedText
-		.replace(/([A-Z])/g, match => ` ${match.toLowerCase()}`)
-		.replace(/^./, match => match.toUpperCase());
-
 const capitalise = string => string.charAt(0).toUpperCase() + string.substring(1).toLowerCase();
 
 const pluralise = model => IRREGULAR_PLURAL_NOUNS_MAP[model] || `${model}s`;
 
 export {
-	camelCaseToSentenceCase,
 	capitalise,
 	pluralise
 };

--- a/src/react/components/form/ArrayItemRemovalButton.jsx
+++ b/src/react/components/form/ArrayItemRemovalButton.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const ArrayItem = props => {
+const ArrayItemRemovalButton = props => {
 
 	const { isRemovalButtonRequired, handleRemovalClick } = props;
 
@@ -23,9 +23,9 @@ const ArrayItem = props => {
 
 };
 
-ArrayItem.propTypes = {
+ArrayItemRemovalButton.propTypes = {
 	isRemovalButtonRequired: PropTypes.bool.isRequired,
 	handleRemovalClick: PropTypes.func.isRequired
 };
 
-export default ArrayItem;
+export default ArrayItemRemovalButton;

--- a/src/react/components/form/Fieldset.jsx
+++ b/src/react/components/form/Fieldset.jsx
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const Fieldset = props => {
+
+	const { header, children } = props;
+
+	return (
+		<fieldset className="fieldset">
+
+			<h2 className="fieldset__header">{ header }:</h2>
+
+			{ children }
+
+		</fieldset>
+	);
+
+};
+
+Fieldset.propTypes = {
+	header: PropTypes.string.isRequired,
+	children: PropTypes.node
+};
+
+export default Fieldset;

--- a/src/react/components/form/FieldsetComponent.jsx
+++ b/src/react/components/form/FieldsetComponent.jsx
@@ -1,0 +1,34 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const FieldsetComponent = props => {
+
+	const { label, isArrayItem, children } = props;
+
+	return (
+		<div
+			className={
+				classNames({
+					'fieldset__component': !isArrayItem,
+					'fieldset__module-component': isArrayItem
+				})
+			}
+		>
+
+			<label className="fieldset__label">{ label }:</label>
+
+			{ children }
+
+		</div>
+	);
+
+};
+
+FieldsetComponent.propTypes = {
+	label: PropTypes.string.isRequired,
+	isArrayItem: PropTypes.bool,
+	children: PropTypes.node.isRequired
+};
+
+export default FieldsetComponent;

--- a/src/react/components/form/FormWrapper.jsx
+++ b/src/react/components/form/FormWrapper.jsx
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { capitalise } from '../../../lib/strings';
+import { FORM_ACTIONS } from '../../../utils/constants';
+
+const FormWrapper = props => {
+
+	const { action, handleSubmit, handleDelete, children } = props;
+
+	const submitButtonText = capitalise(action);
+
+	const isDeleteButtonRequired = (action === FORM_ACTIONS.update);
+
+	return (
+		<form className="form" onSubmit={handleSubmit}>
+
+			{ children }
+
+			<button className="button">{ submitButtonText }</button>
+
+			{
+				isDeleteButtonRequired && (
+					<button className="button" onClick={handleDelete}>Delete</button>
+				)
+			}
+
+		</form>
+	);
+
+};
+
+FormWrapper.propTypes = {
+	handleSubmit: PropTypes.func.isRequired,
+	handleDelete: PropTypes.func.isRequired,
+	action: PropTypes.string.isRequired,
+	children: PropTypes.node.isRequired
+};
+
+export default FormWrapper;

--- a/src/react/components/form/Input.jsx
+++ b/src/react/components/form/Input.jsx
@@ -13,7 +13,7 @@ const Input = props => {
 
 	return (
 		<input
-			value={value}
+			value={value || ''}
 			className={className}
 			maxLength="1000"
 			type="text"
@@ -24,7 +24,7 @@ const Input = props => {
 };
 
 Input.propTypes = {
-	value: PropTypes.string.isRequired,
+	value: PropTypes.string,
 	hasErrors: PropTypes.bool.isRequired,
 	handleChange: PropTypes.func.isRequired
 };

--- a/src/react/components/form/InputAndErrors.jsx
+++ b/src/react/components/form/InputAndErrors.jsx
@@ -1,0 +1,37 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+import { Input, InputErrors } from '.';
+
+const InputAndErrors = props => {
+
+	const { value, errors, handleChange } = props;
+
+	return (
+		<React.Fragment>
+
+			<Input
+				value={value}
+				hasErrors={!!errors}
+				handleChange={handleChange}
+			/>
+
+			{
+				!!errors && (
+					<InputErrors errors={errors} />
+				)
+			}
+
+		</React.Fragment>
+	);
+
+};
+
+InputAndErrors.propTypes = {
+	value: PropTypes.string,
+	errors: ImmutablePropTypes.list,
+	handleChange: PropTypes.func.isRequired
+};
+
+export default InputAndErrors;

--- a/src/react/components/form/InputErrors.jsx
+++ b/src/react/components/form/InputErrors.jsx
@@ -1,14 +1,13 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
 const InputErrors = props => {
 
-	const { errors, statePath } = props;
+	const { errors } = props;
 
 	return (
-		errors.map(errorText =>
-			<ul key={`${statePath.join('-')}-error`}>
+		errors.map((errorText, index) =>
+			<ul key={index}>
 
 				<li className="field__error-list-item">{ errorText }</li>
 
@@ -19,8 +18,7 @@ const InputErrors = props => {
 };
 
 InputErrors.propTypes = {
-	errors: ImmutablePropTypes.list.isRequired,
-	statePath: PropTypes.array.isRequired
+	errors: ImmutablePropTypes.list.isRequired
 };
 
 export default InputErrors;

--- a/src/react/components/form/index.js
+++ b/src/react/components/form/index.js
@@ -1,11 +1,19 @@
-import ArrayItem from './ArrayItem';
+import ArrayItemRemovalButton from './ArrayItemRemovalButton';
+import Fieldset from './Fieldset';
+import FieldsetComponent from './FieldsetComponent';
 import Form from './Form';
+import FormWrapper from './FormWrapper';
 import Input from './Input';
+import InputAndErrors from './InputAndErrors';
 import InputErrors from './InputErrors';
 
 export {
-	ArrayItem,
+	ArrayItemRemovalButton,
+	Fieldset,
+	FieldsetComponent,
 	Form,
+	FormWrapper,
 	Input,
+	InputAndErrors,
 	InputErrors
 };

--- a/src/react/components/index.js
+++ b/src/react/components/index.js
@@ -1,4 +1,3 @@
-import { Form } from './form';
 import ErrorMessage from './ErrorMessage';
 import Footer from './Footer';
 import FormattedJson from './FormattedJson';
@@ -13,7 +12,6 @@ import withInstancePageTitle from './withInstancePageTitle';
 export {
 	ErrorMessage,
 	Footer,
-	Form,
 	FormattedJson,
 	Header,
 	InstanceDocumentTitle,

--- a/src/react/components/instance-forms/CharacterForm.jsx
+++ b/src/react/components/instance-forms/CharacterForm.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+
+import { Fieldset, Form, FormWrapper, InputAndErrors } from '../form';
+import { createInstance, updateInstance, deleteInstance } from '../../../redux/actions/model';
+
+class CharacterForm extends Form {
+
+	render () {
+
+		if (this.props.redirectPath) return this.performRedirect();
+
+		return (
+			<FormWrapper
+				action={this.props.action}
+				handleSubmit={this.handleSubmit}
+				handleDelete={this.handleDelete}
+			>
+
+				<Fieldset header={'Name'}>
+
+					<InputAndErrors
+						value={this.state.name}
+						errors={this.state.errors?.get('name')}
+						handleChange={event => this.handleChange(['name'], event)}
+					/>
+
+				</Fieldset>
+
+				<Fieldset header={'Differentiator'}>
+
+					<InputAndErrors
+						value={this.state.differentiator}
+						errors={this.state.errors?.get('differentiator')}
+						handleChange={event => this.handleChange(['differentiator'], event)}
+					/>
+
+				</Fieldset>
+
+			</FormWrapper>
+		);
+
+	}
+
+}
+
+CharacterForm.propTypes = {
+	character: ImmutablePropTypes.map.isRequired,
+	characterFormData: ImmutablePropTypes.map.isRequired
+};
+
+const mapStateToProps = state => ({
+	character: state.get('character'),
+	characterFormData: state.get('characterFormData')
+});
+
+export default connect(mapStateToProps, { createInstance, updateInstance, deleteInstance })(CharacterForm);

--- a/src/react/components/instance-forms/PersonForm.jsx
+++ b/src/react/components/instance-forms/PersonForm.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+
+import { Fieldset, Form, FormWrapper, InputAndErrors } from '../form';
+import { createInstance, updateInstance, deleteInstance } from '../../../redux/actions/model';
+
+class PersonForm extends Form {
+
+	render () {
+
+		if (this.props.redirectPath) return this.performRedirect();
+
+		return (
+			<FormWrapper
+				action={this.props.action}
+				handleSubmit={this.handleSubmit}
+				handleDelete={this.handleDelete}
+			>
+
+				<Fieldset header={'Name'}>
+
+					<InputAndErrors
+						value={this.state.name}
+						errors={this.state.errors?.get('name')}
+						handleChange={event => this.handleChange(['name'], event)}
+					/>
+
+				</Fieldset>
+
+				<Fieldset header={'Differentiator'}>
+
+					<InputAndErrors
+						value={this.state.differentiator}
+						errors={this.state.errors?.get('differentiator')}
+						handleChange={event => this.handleChange(['differentiator'], event)}
+					/>
+
+				</Fieldset>
+
+			</FormWrapper>
+		);
+
+	}
+
+}
+
+PersonForm.propTypes = {
+	person: ImmutablePropTypes.map.isRequired,
+	personFormData: ImmutablePropTypes.map.isRequired
+};
+
+const mapStateToProps = state => ({
+	person: state.get('person'),
+	personFormData: state.get('personFormData')
+});
+
+export default connect(mapStateToProps, { createInstance, updateInstance, deleteInstance })(PersonForm);

--- a/src/react/components/instance-forms/PlaytextForm.jsx
+++ b/src/react/components/instance-forms/PlaytextForm.jsx
@@ -1,0 +1,258 @@
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+
+import { ArrayItemRemovalButton, Fieldset, FieldsetComponent, Form, FormWrapper, InputAndErrors } from '../form';
+import { createInstance, updateInstance, deleteInstance } from '../../../redux/actions/model';
+
+class PlaytextForm extends Form {
+
+	renderWriters (writers, writersStatePath) {
+
+		return (
+			<FieldsetComponent label={'Writers'} isArrayItem={true}>
+
+				{
+					writers.map((writer, index) => {
+
+						const statePath = writersStatePath.concat([index]);
+
+						return (
+							<div className={'fieldset__module fieldset__module--nested'} key={index}>
+
+								<ArrayItemRemovalButton
+									isRemovalButtonRequired={this.isRemovalButtonRequired(index, writers.size)}
+									handleRemovalClick={event => this.handleRemovalClick(statePath, event)}
+								/>
+
+								<FieldsetComponent label={'Name'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={writer.get('name')}
+										errors={writer.getIn(['errors', 'name'])}
+										handleChange={event => this.handleChange(statePath.concat(['name']), event)}
+									/>
+
+								</FieldsetComponent>
+
+								<FieldsetComponent label={'Differentiator'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={writer.get('differentiator')}
+										errors={writer.getIn(['errors', 'differentiator'])}
+										handleChange={event => this.handleChange(statePath.concat(['differentiator']), event)}
+									/>
+
+								</FieldsetComponent>
+
+							</div>
+						);
+
+					})
+				}
+
+			</FieldsetComponent>
+		);
+
+	}
+
+	renderWriterGroups (writerGroups) {
+
+		return (
+			<Fieldset header={'Writer groups'}>
+
+				{
+					writerGroups.map((writerGroup, index) => {
+
+						return (
+							<div className={'fieldset__module'} key={index}>
+
+								<ArrayItemRemovalButton
+									isRemovalButtonRequired={this.isRemovalButtonRequired(index, writerGroups.size)}
+									handleRemovalClick={event => this.handleRemovalClick(['writerGroups', index], event)}
+								/>
+
+								<FieldsetComponent label={'Name'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={writerGroup.get('name')}
+										errors={writerGroup.getIn(['errors', 'name'])}
+										handleChange={event => this.handleChange(['writerGroups', index, 'name'], event)}
+									/>
+
+								</FieldsetComponent>
+
+								{ this.renderWriters(writerGroup.get('writers'), ['writerGroups', index, 'writers']) }
+
+							</div>
+						);
+
+					})
+				}
+
+			</Fieldset>
+		);
+
+	}
+
+	renderCharacters (characters, charactersStatePath) {
+
+		return (
+			<FieldsetComponent label={'Characters'} isArrayItem={true}>
+
+				{
+					characters.map((character, index) => {
+
+						const statePath = charactersStatePath.concat([index]);
+
+						return (
+							<div className={'fieldset__module fieldset__module--nested'} key={index}>
+
+								<ArrayItemRemovalButton
+									isRemovalButtonRequired={this.isRemovalButtonRequired(index, characters.size)}
+									handleRemovalClick={event => this.handleRemovalClick(statePath, event)}
+								/>
+
+								<FieldsetComponent label={'Name'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={character.get('name')}
+										errors={character.getIn(['errors', 'name'])}
+										handleChange={event => this.handleChange(statePath.concat(['name']), event)}
+									/>
+
+								</FieldsetComponent>
+
+								<FieldsetComponent label={'Underlying name'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={character.get('underlyingName')}
+										errors={character.getIn(['errors', 'underlyingName'])}
+										handleChange={event => this.handleChange(statePath.concat(['underlyingName']), event)}
+									/>
+
+								</FieldsetComponent>
+
+								<FieldsetComponent label={'Differentiator'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={character.get('differentiator')}
+										errors={character.getIn(['errors', 'differentiator'])}
+										handleChange={event => this.handleChange(statePath.concat(['differentiator']), event)}
+									/>
+
+								</FieldsetComponent>
+
+								<FieldsetComponent label={'Qualifier'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={character.get('qualifier')}
+										errors={character.getIn(['errors', 'qualifier'])}
+										handleChange={event => this.handleChange(statePath.concat(['qualifier']), event)}
+									/>
+
+								</FieldsetComponent>
+
+							</div>
+						);
+
+					})
+				}
+
+			</FieldsetComponent>
+		);
+
+	}
+
+	renderCharacterGroups (characterGroups) {
+
+		return (
+			<Fieldset header={'Character groups'}>
+
+				{
+					characterGroups.map((characterGroup, index) => {
+
+						return (
+							<div className={'fieldset__module'} key={index}>
+
+								<ArrayItemRemovalButton
+									isRemovalButtonRequired={this.isRemovalButtonRequired(index, characterGroups.size)}
+									handleRemovalClick={event => this.handleRemovalClick(['characterGroups', index], event)}
+								/>
+
+								<FieldsetComponent label={'Name'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={characterGroup.get('name')}
+										errors={characterGroup.getIn(['errors', 'name'])}
+										handleChange={event => this.handleChange(['characterGroups', index, 'name'], event)}
+									/>
+
+								</FieldsetComponent>
+
+								{ this.renderCharacters(characterGroup.get('characters'), ['characterGroups', index, 'characters']) }
+
+							</div>
+						);
+
+					})
+				}
+
+			</Fieldset>
+		);
+
+	}
+
+	render () {
+
+		if (this.props.redirectPath) return this.performRedirect();
+
+		return (
+			<FormWrapper
+				action={this.props.action}
+				handleSubmit={this.handleSubmit}
+				handleDelete={this.handleDelete}
+			>
+
+				<Fieldset header={'Name'}>
+
+					<InputAndErrors
+						value={this.state.name}
+						errors={this.state.errors?.get('name')}
+						handleChange={event => this.handleChange(['name'], event)}
+					/>
+
+				</Fieldset>
+
+				<Fieldset header={'Differentiator'}>
+
+					<InputAndErrors
+						value={this.state.differentiator}
+						errors={this.state.errors?.get('differentiator')}
+						handleChange={event => this.handleChange(['differentiator'], event)}
+					/>
+
+				</Fieldset>
+
+				{ !!this.state.writerGroups && this.renderWriterGroups(this.state.writerGroups) }
+
+				{ !!this.state.characterGroups && this.renderCharacterGroups(this.state.characterGroups) }
+
+			</FormWrapper>
+		);
+
+	}
+
+}
+
+PlaytextForm.propTypes = {
+	playtext: ImmutablePropTypes.map.isRequired,
+	playtextFormData: ImmutablePropTypes.map.isRequired
+};
+
+const mapStateToProps = state => ({
+	playtext: state.get('playtext'),
+	playtextFormData: state.get('playtextFormData')
+});
+
+export default connect(mapStateToProps, { createInstance, updateInstance, deleteInstance })(PlaytextForm);

--- a/src/react/components/instance-forms/ProductionForm.jsx
+++ b/src/react/components/instance-forms/ProductionForm.jsx
@@ -1,0 +1,216 @@
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+
+import { ArrayItemRemovalButton, Fieldset, FieldsetComponent, Form, FormWrapper, InputAndErrors } from '../form';
+import { createInstance, updateInstance, deleteInstance } from '../../../redux/actions/model';
+
+class ProductionForm extends Form {
+
+	renderCastMemberRoles (roles, rolesStatePath) {
+
+		return (
+			<FieldsetComponent label={'Roles'} isArrayItem={true}>
+
+				{
+					roles.map((role, index) => {
+
+						const statePath = rolesStatePath.concat([index]);
+
+						return (
+							<div className={'fieldset__module fieldset__module--nested'} key={index}>
+
+								<ArrayItemRemovalButton
+									isRemovalButtonRequired={this.isRemovalButtonRequired(index, roles.size)}
+									handleRemovalClick={event => this.handleRemovalClick(statePath, event)}
+								/>
+
+								<FieldsetComponent label={'Name'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={role.get('name')}
+										errors={role.getIn(['errors', 'name'])}
+										handleChange={event => this.handleChange(statePath.concat(['name']), event)}
+									/>
+
+								</FieldsetComponent>
+
+								<FieldsetComponent label={'Character name'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={role.get('characterName')}
+										errors={role.getIn(['errors', 'characterName'])}
+										handleChange={event => this.handleChange(statePath.concat(['characterName']), event)}
+									/>
+
+								</FieldsetComponent>
+
+								<FieldsetComponent label={'Character differentiator'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={role.get('characterDifferentiator')}
+										errors={role.getIn(['errors', 'characterDifferentiator'])}
+										handleChange={event => this.handleChange(statePath.concat(['characterDifferentiator']), event)}
+									/>
+
+								</FieldsetComponent>
+
+								<FieldsetComponent label={'Qualifier'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={role.get('qualifier')}
+										errors={role.getIn(['errors', 'qualifier'])}
+										handleChange={event => this.handleChange(statePath.concat(['qualifier']), event)}
+									/>
+
+								</FieldsetComponent>
+
+							</div>
+						);
+
+					})
+				}
+
+			</FieldsetComponent>
+		);
+
+	}
+
+	renderCast (cast) {
+
+		return (
+			<Fieldset header={'Cast'}>
+
+				{
+					cast.map((castMember, index) => {
+
+						return (
+							<div className={'fieldset__module'} key={index}>
+
+								<ArrayItemRemovalButton
+									isRemovalButtonRequired={this.isRemovalButtonRequired(index, cast.size)}
+									handleRemovalClick={event => this.handleRemovalClick(['cast', index], event)}
+								/>
+
+								<FieldsetComponent label={'Name'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={castMember.get('name')}
+										errors={castMember.getIn(['errors', 'name'])}
+										handleChange={event => this.handleChange(['cast', index, 'name'], event)}
+									/>
+
+								</FieldsetComponent>
+
+								<FieldsetComponent label={'Differentiator'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={castMember.get('differentiator')}
+										errors={castMember.getIn(['errors', 'differentiator'])}
+										handleChange={event => this.handleChange(['cast', index, 'differentiator'], event)}
+									/>
+
+								</FieldsetComponent>
+
+								{ this.renderCastMemberRoles(castMember.get('roles'), ['cast', index, 'roles']) }
+
+							</div>
+						);
+
+					})
+				}
+
+			</Fieldset>
+		);
+
+	}
+
+	render () {
+
+		if (this.props.redirectPath) return this.performRedirect();
+
+		return (
+			<FormWrapper
+				action={this.props.action}
+				handleSubmit={this.handleSubmit}
+				handleDelete={this.handleDelete}
+			>
+
+				<Fieldset header={'Name'}>
+
+					<InputAndErrors
+						value={this.state.name}
+						errors={this.state.errors?.get('name')}
+						handleChange={event => this.handleChange(['name'], event)}
+					/>
+
+				</Fieldset>
+
+				<Fieldset header={'Playtext'}>
+
+					<FieldsetComponent label={'Name'}>
+
+						<InputAndErrors
+							value={this.state.playtext?.get('name')}
+							errors={this.state.playtext?.getIn(['errors', 'name'])}
+							handleChange={event => this.handleChange(['playtext', 'name'], event)}
+						/>
+
+					</FieldsetComponent>
+
+					<FieldsetComponent label={'Differentiator'}>
+
+						<InputAndErrors
+							value={this.state.playtext?.get('differentiator')}
+							errors={this.state.playtext?.getIn(['errors', 'differentiator'])}
+							handleChange={event => this.handleChange(['playtext', 'differentiator'], event)}
+						/>
+
+					</FieldsetComponent>
+
+				</Fieldset>
+
+				<Fieldset header={'Theatre'}>
+
+					<FieldsetComponent label={'Name'}>
+
+						<InputAndErrors
+							value={this.state.theatre?.get('name')}
+							errors={this.state.theatre?.getIn(['errors', 'name'])}
+							handleChange={event => this.handleChange(['theatre', 'name'], event)}
+						/>
+
+					</FieldsetComponent>
+
+					<FieldsetComponent label={'Differentiator'}>
+
+						<InputAndErrors
+							value={this.state.theatre?.get('differentiator')}
+							errors={this.state.theatre?.getIn(['errors', 'differentiator'])}
+							handleChange={event => this.handleChange(['theatre', 'differentiator'], event)}
+						/>
+
+					</FieldsetComponent>
+
+				</Fieldset>
+
+				{ !!this.state.cast && this.renderCast(this.state.cast) }
+
+			</FormWrapper>
+		);
+
+	}
+
+}
+
+ProductionForm.propTypes = {
+	production: ImmutablePropTypes.map.isRequired,
+	productionFormData: ImmutablePropTypes.map.isRequired
+};
+
+const mapStateToProps = state => ({
+	production: state.get('production'),
+	productionFormData: state.get('productionFormData')
+});
+
+export default connect(mapStateToProps, { createInstance, updateInstance, deleteInstance })(ProductionForm);

--- a/src/react/components/instance-forms/TheatreForm.jsx
+++ b/src/react/components/instance-forms/TheatreForm.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+
+import { ArrayItemRemovalButton, Fieldset, FieldsetComponent, Form, FormWrapper, InputAndErrors } from '../form';
+import { createInstance, updateInstance, deleteInstance } from '../../../redux/actions/model';
+
+class TheatreForm extends Form {
+
+	renderSubTheatres (subTheatres) {
+
+		return (
+			<Fieldset header={'Sub-theatres'}>
+
+				{
+					subTheatres?.map((subTheatre, index) => {
+
+						return (
+							<div className={'fieldset__module'} key={index}>
+
+								<ArrayItemRemovalButton
+									isRemovalButtonRequired={this.isRemovalButtonRequired(index, subTheatres.size)}
+									handleRemovalClick={event => this.handleRemovalClick(['subTheatres', index], event)}
+								/>
+
+								<FieldsetComponent label={'Name'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={subTheatre.get('name')}
+										errors={subTheatre.getIn(['errors', 'name'])}
+										handleChange={event => this.handleChange(['subTheatres', index, 'name'], event)}
+									/>
+
+								</FieldsetComponent>
+
+								<FieldsetComponent label={'Differentiator'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={subTheatre.get('differentiator')}
+										errors={subTheatre.getIn(['errors', 'differentiator'])}
+										handleChange={event => this.handleChange(['subTheatres', index, 'differentiator'], event)}
+									/>
+
+								</FieldsetComponent>
+
+							</div>
+						);
+
+					})
+				}
+
+			</Fieldset>
+		);
+
+	}
+
+	render () {
+
+		if (this.props.redirectPath) return this.performRedirect();
+
+		return (
+			<FormWrapper
+				action={this.props.action}
+				handleSubmit={this.handleSubmit}
+				handleDelete={this.handleDelete}
+			>
+
+				<Fieldset header={'Name'}>
+
+					<InputAndErrors
+						value={this.state.name}
+						errors={this.state.errors?.get('name')}
+						handleChange={event => this.handleChange(['name'], event)}
+					/>
+
+				</Fieldset>
+
+				<Fieldset header={'Differentiator'}>
+
+					<InputAndErrors
+						value={this.state.differentiator}
+						errors={this.state.errors?.get('differentiator')}
+						handleChange={event => this.handleChange(['differentiator'], event)}
+					/>
+
+				</Fieldset>
+
+				{ !!this.state.subTheatres && this.renderSubTheatres(this.state.subTheatres) }
+
+			</FormWrapper>
+		);
+
+	}
+
+}
+
+TheatreForm.propTypes = {
+	theatre: ImmutablePropTypes.map.isRequired,
+	theatreFormData: ImmutablePropTypes.map.isRequired
+};
+
+const mapStateToProps = state => ({
+	theatre: state.get('theatre'),
+	theatreFormData: state.get('theatreFormData')
+});
+
+export default connect(mapStateToProps, { createInstance, updateInstance, deleteInstance })(TheatreForm);

--- a/src/react/components/instance-forms/index.js
+++ b/src/react/components/instance-forms/index.js
@@ -1,0 +1,13 @@
+import CharacterForm from './CharacterForm';
+import PersonForm from './PersonForm';
+import PlaytextForm from './PlaytextForm';
+import ProductionForm from './ProductionForm';
+import TheatreForm from './TheatreForm';
+
+export {
+	CharacterForm,
+	PersonForm,
+	PlaytextForm,
+	ProductionForm,
+	TheatreForm
+};

--- a/src/react/pages/instances/Character.jsx
+++ b/src/react/pages/instances/Character.jsx
@@ -1,7 +1,9 @@
+import { Map } from 'immutable';
 import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
+import { CharacterForm } from '../../components/instance-forms';
 import { InstanceWrapper } from '../../utils';
 
 class Character extends React.Component {
@@ -13,8 +15,15 @@ class Character extends React.Component {
 		return (
 			<InstanceWrapper
 				instance={character}
-				formData={characterFormData}
+				formAction={characterFormData.get('action')}
 			>
+
+				<CharacterForm
+					instance={characterFormData.get('instance', Map())}
+					action={characterFormData.get('action', 'Submit')}
+					redirectPath={characterFormData.get('redirectPath')}
+				/>
+
 			</InstanceWrapper>
 		);
 

--- a/src/react/pages/instances/Person.jsx
+++ b/src/react/pages/instances/Person.jsx
@@ -1,7 +1,9 @@
+import { Map } from 'immutable';
 import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
+import { PersonForm } from '../../components/instance-forms';
 import { InstanceWrapper } from '../../utils';
 
 class Person extends React.Component {
@@ -13,8 +15,15 @@ class Person extends React.Component {
 		return (
 			<InstanceWrapper
 				instance={person}
-				formData={personFormData}
+				formAction={personFormData.get('action')}
 			>
+
+				<PersonForm
+					instance={personFormData.get('instance', Map())}
+					action={personFormData.get('action', 'Submit')}
+					redirectPath={personFormData.get('redirectPath')}
+				/>
+
 			</InstanceWrapper>
 		);
 

--- a/src/react/pages/instances/Playtext.jsx
+++ b/src/react/pages/instances/Playtext.jsx
@@ -1,7 +1,9 @@
+import { Map } from 'immutable';
 import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
+import { PlaytextForm } from '../../components/instance-forms';
 import { InstanceWrapper } from '../../utils';
 
 class Playtext extends React.Component {
@@ -13,8 +15,15 @@ class Playtext extends React.Component {
 		return (
 			<InstanceWrapper
 				instance={playtext}
-				formData={playtextFormData}
+				formAction={playtextFormData.get('action')}
 			>
+
+				<PlaytextForm
+					instance={playtextFormData.get('instance', Map())}
+					action={playtextFormData.get('action', 'Submit')}
+					redirectPath={playtextFormData.get('redirectPath')}
+				/>
+
 			</InstanceWrapper>
 		);
 

--- a/src/react/pages/instances/Production.jsx
+++ b/src/react/pages/instances/Production.jsx
@@ -1,7 +1,9 @@
+import { Map } from 'immutable';
 import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
+import { ProductionForm } from '../../components/instance-forms';
 import { InstanceWrapper } from '../../utils';
 
 class Production extends React.Component {
@@ -13,8 +15,15 @@ class Production extends React.Component {
 		return (
 			<InstanceWrapper
 				instance={production}
-				formData={productionFormData}
+				formAction={productionFormData.get('action')}
 			>
+
+				<ProductionForm
+					instance={productionFormData.get('instance', Map())}
+					action={productionFormData.get('action', 'Submit')}
+					redirectPath={productionFormData.get('redirectPath')}
+				/>
+
 			</InstanceWrapper>
 		);
 

--- a/src/react/pages/instances/Theatre.jsx
+++ b/src/react/pages/instances/Theatre.jsx
@@ -1,7 +1,9 @@
+import { Map } from 'immutable';
 import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
+import { TheatreForm } from '../../components/instance-forms';
 import { InstanceWrapper } from '../../utils';
 
 class Theatre extends React.Component {
@@ -13,8 +15,15 @@ class Theatre extends React.Component {
 		return (
 			<InstanceWrapper
 				instance={theatre}
-				formData={theatreFormData}
+				formAction={theatreFormData.get('action')}
 			>
+
+				<TheatreForm
+					instance={theatreFormData.get('instance', Map())}
+					action={theatreFormData.get('action', 'Submit')}
+					redirectPath={theatreFormData.get('redirectPath')}
+				/>
+
 			</InstanceWrapper>
 		);
 

--- a/src/react/utils/InstanceWrapper.jsx
+++ b/src/react/utils/InstanceWrapper.jsx
@@ -1,9 +1,8 @@
-import { Map } from 'immutable';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import {
-	Form,
 	FormattedJson,
 	InstanceDocumentTitle,
 	InstanceLabel,
@@ -15,7 +14,7 @@ class InstanceWrapper extends React.Component {
 
 	render () {
 
-		const { instance, formData } = this.props;
+		const { instance, formAction, children } = this.props;
 
 		const InstancePageTitle = withInstancePageTitle(PageTitle);
 
@@ -23,12 +22,12 @@ class InstanceWrapper extends React.Component {
 			<React.Fragment>
 
 				{
-					instance.get('name') && instance.get('model') && formData.get('action') && (
+					instance.get('name') && instance.get('model') && formAction && (
 						<InstanceDocumentTitle
 							name={instance.get('name')}
 							differentiator={instance.get('differentiator')}
 							model={instance.get('model')}
-							formAction={formData.get('action')}
+							formAction={formAction}
 						/>
 					)
 				}
@@ -39,16 +38,12 @@ class InstanceWrapper extends React.Component {
 					name={instance.get('name')}
 					differentiator={instance.get('differentiator')}
 					model={instance.get('model')}
-					formAction={formData.get('action')}
+					formAction={formAction}
 				/>
 
 				<FormattedJson data={instance} />
 
-				<Form
-					instance={formData.get('instance', Map())}
-					action={formData.get('action', 'Submit')}
-					redirectPath={formData.get('redirectPath')}
-				/>
+				{ children }
 
 			</React.Fragment>
 		);
@@ -59,7 +54,8 @@ class InstanceWrapper extends React.Component {
 
 InstanceWrapper.propTypes = {
 	instance: ImmutablePropTypes.map.isRequired,
-	formData: ImmutablePropTypes.map.isRequired
+	formAction: PropTypes.string,
+	children: PropTypes.node.isRequired
 };
 
 export default InstanceWrapper;

--- a/test/src/lib/strings.test.js
+++ b/test/src/lib/strings.test.js
@@ -1,28 +1,8 @@
 import { expect } from 'chai';
 
-import { camelCaseToSentenceCase, capitalise, pluralise } from '../../../src/lib/strings';
+import { capitalise, pluralise } from '../../../src/lib/strings';
 
 describe('Strings module', () => {
-
-	describe('camelCaseToSentenceCase function', () => {
-
-		it('converts single word camel-cased values to sentence case', () => {
-
-			const result = camelCaseToSentenceCase('name');
-
-			expect(result).to.equal('Name');
-
-		});
-
-		it('converts multi-word camel-cased values to sentence case', () => {
-
-			const result = camelCaseToSentenceCase('characterName');
-
-			expect(result).to.equal('Character name');
-
-		});
-
-	});
 
 	describe('capitalise function', () => {
 


### PR DESCRIPTION
The form component needs to display new input types alongside the existing text inputs (e.g. a checkbox input to apply the `isOriginalVersionWriter` value).

This is set to become increasingly complex with introduction of varied model types within an array (e.g. writers will eventually include people, companies, source material (which in turn can be a playtext or another type of material)).

The recursive function that currently renders the form will become too complex to be able to clearly apply the required modifications and so it makes more sense to split the form out so that each model has its own form component in which it can clearly include its specific requirements and vary on those where required. This PR applies those changes.