### PR TITLE
Add playtext form writerGroup isOriginalVersionWriter checkbox

### DIFF
--- a/src/react/components/form/Form.jsx
+++ b/src/react/components/form/Form.jsx
@@ -49,9 +49,15 @@ class Form extends React.Component {
 
 	}
 
-	getNewStateForRootAttr (rootAttr, statePath, eventTargetValue) {
+	getNewStateForRootAttr (rootAttr, statePath, eventTarget) {
 
-		let newStateForRootAttr = setIn(this.state[rootAttr], statePath, eventTargetValue);
+		const isUpatedCheckbox = eventTarget.type === 'checkbox';
+
+		const updateValue = isUpatedCheckbox ? eventTarget.checked : eventTarget.value;
+
+		let newStateForRootAttr = setIn(this.state[rootAttr], statePath, updateValue);
+
+		if (isUpatedCheckbox) return newStateForRootAttr;
 
 		const indexOfLastNumberInStatePath =
 			statePath
@@ -88,7 +94,7 @@ class Form extends React.Component {
 
 		const rootAttr = statePath.shift();
 
-		this.setState({ [rootAttr]: this.getNewStateForRootAttr(rootAttr, statePath, event.target.value) });
+		this.setState({ [rootAttr]: this.getNewStateForRootAttr(rootAttr, statePath, event.target) });
 
 	}
 

--- a/src/react/components/instance-forms/PlaytextForm.jsx
+++ b/src/react/components/instance-forms/PlaytextForm.jsx
@@ -82,6 +82,16 @@ class PlaytextForm extends Form {
 
 								</FieldsetComponent>
 
+								<FieldsetComponent label={'Original version writers (if subsequent version)'} isArrayItem={true}>
+
+									<input
+										type="checkbox"
+										checked={writerGroup.get('isOriginalVersionWriter') || false}
+										onChange={event => this.handleChange(['writerGroups', index, 'isOriginalVersionWriter'], event)}
+									/>
+
+								</FieldsetComponent>
+
 								{ this.renderWriters(writerGroup.get('writers'), ['writerGroups', index, 'writers']) }
 
 							</div>


### PR DESCRIPTION
Enable editing of writerGroup `isOriginalVersionWriter` value as added to the API in this PR: https://github.com/andygout/theatrebase-api/pull/305.

Changing the text input values will add an extra array item, but it is by design that checking this checkbox will not result in the same effect (trying it out feels a bit weird).

![Screenshot 2020-12-02 at 16 24 26](https://user-images.githubusercontent.com/10484515/100901697-0823ec00-34bc-11eb-8bc7-dc7bbf36fc88.png)