### PR TITLE
Add playtext original version playtext input

### DIFF
--- a/src/react/components/instance-forms/PlaytextForm.jsx
+++ b/src/react/components/instance-forms/PlaytextForm.jsx
@@ -244,6 +244,30 @@ class PlaytextForm extends Form {
 
 				</Fieldset>
 
+				<Fieldset header={'Original version playtext'}>
+
+					<FieldsetComponent label={'Name'}>
+
+						<InputAndErrors
+							value={this.state.originalVersionPlaytext?.get('name')}
+							errors={this.state.originalVersionPlaytext?.getIn(['errors', 'name'])}
+							handleChange={event => this.handleChange(['originalVersionPlaytext', 'name'], event)}
+						/>
+
+					</FieldsetComponent>
+
+					<FieldsetComponent label={'Differentiator'}>
+
+						<InputAndErrors
+							value={this.state.originalVersionPlaytext?.get('differentiator')}
+							errors={this.state.originalVersionPlaytext?.getIn(['errors', 'differentiator'])}
+							handleChange={event => this.handleChange(['originalVersionPlaytext', 'differentiator'], event)}
+						/>
+
+					</FieldsetComponent>
+
+				</Fieldset>
+
 				{ !!this.state.writerGroups && this.renderWriterGroups(this.state.writerGroups) }
 
 				{ !!this.state.characterGroups && this.renderCharacterGroups(this.state.characterGroups) }


### PR DESCRIPTION
Enable editing in playtext form of original version playtext values as added to the API in this PR: https://github.com/andygout/theatrebase-api/pull/310.

![Screenshot 2020-12-13 at 17 18 08](https://user-images.githubusercontent.com/10484515/102018792-67f57f00-3d67-11eb-9fb8-c159df1560b4.png)