### PR TITLE
Add playtext form writer model radio buttons

### DIFF
--- a/src/react/components/instance-forms/PlaytextForm.jsx
+++ b/src/react/components/instance-forms/PlaytextForm.jsx
@@ -45,6 +45,26 @@ class PlaytextForm extends Form {
 
 								</FieldsetComponent>
 
+								<FieldsetComponent label={'Model'} isArrayItem={true}>
+
+									<input
+										type={'radio'}
+										value={'person'}
+										checked={writer.get('model') === 'person'}
+										onChange={event => this.handleChange(statePath.concat(['model']), event)}
+									/>
+									<label>&nbsp;Person</label>
+
+									<input
+										type={'radio'}
+										value={'playtext'}
+										checked={writer.get('model') === 'playtext'}
+										onChange={event => this.handleChange(statePath.concat(['model']), event)}
+									/>
+									<label>&nbsp;Playtext (source material)</label>
+
+								</FieldsetComponent>
+
 							</div>
 						);
 


### PR DESCRIPTION
Enable editing in playtext form of writer `model` value as added to the API in this PR: https://github.com/andygout/theatrebase-api/pull/314.

![Screenshot 2020-12-31 at 09 12 21](https://user-images.githubusercontent.com/10484515/103403550-78b83a00-4b48-11eb-876e-41ee327dcbb0.png)