### PR TITLE
Add material writing entity model company radio button

### DIFF
--- a/src/react/components/instance-forms/MaterialForm.jsx
+++ b/src/react/components/instance-forms/MaterialForm.jsx
@@ -11,7 +11,7 @@ class MaterialForm extends Form {
 	renderWritingEntities (writingEntities, writingEntitiesStatePath) {
 
 		return (
-			<FieldsetComponent label={'Writing entities (people, materials)'} isArrayItem={true}>
+			<FieldsetComponent label={'Writing entities (people, companies, materials)'} isArrayItem={true}>
 
 				{
 					writingEntities.map((writingEntity, index) => {
@@ -55,6 +55,14 @@ class MaterialForm extends Form {
 										onChange={event => this.handleChange(statePath.concat(['model']), event)}
 									/>
 									<label>&nbsp;Person</label>
+
+									<input
+										type={'radio'}
+										value={'company'}
+										checked={writingEntity.get('model') === 'company'}
+										onChange={event => this.handleChange(statePath.concat(['model']), event)}
+									/>
+									<label>&nbsp;Company</label>
 
 									<input
 										type={'radio'}


### PR DESCRIPTION
Updates the CMS front-end so as to be able to assign companies as writing entities of materials, as enabled by this API PR: https://github.com/andygout/theatrebase-api/pull/334.

---

#### The Dark Philosophers (material) - edit form
![the-dark-philosophers-material-edit-form](https://user-images.githubusercontent.com/10484515/106177532-8afdb600-6190-11eb-91a1-bf98e986926f.png)