### PR TITLE
Handle production creative team member (company) credited members

### DIFF
--- a/src/react/components/form/Form.jsx
+++ b/src/react/components/form/Form.jsx
@@ -49,11 +49,11 @@ class Form extends React.Component {
 
 	}
 
-	getNewStateForRootAttr (rootAttr, statePath, eventTarget) {
+	getNewStateForRootAttr (rootAttr, statePath, revision) {
 
-		let newStateForRootAttr = setIn(this.state[rootAttr], statePath, eventTarget.value);
+		let newStateForRootAttr = setIn(this.state[rootAttr], statePath, revision.value);
 
-		if (eventTarget.type !== 'text') return newStateForRootAttr;
+		if (revision.type !== 'text') return newStateForRootAttr;
 
 		const indexOfLastNumberInStatePath =
 			statePath


### PR DESCRIPTION
This PR adds functionality to be able to add/edit production creative team credits as implemented in this API PR: https://github.com/andygout/theatrebase-api/pull/368.

---

### Edit production form (Three Sisters at Lyttelton Theatre)

#### Creative team member is person
![person](https://user-images.githubusercontent.com/10484515/111866920-b28b2680-8968-11eb-86a9-55e390e9c90a.png)

---

#### Creative team member is company
Fields appear in which to enter information about the company credited members (people) for that specific production
![company](https://user-images.githubusercontent.com/10484515/111866953-cfbff500-8968-11eb-8ad5-c514139bb505.png)