### PR TITLE
Add production producer credits fieldset

### DIFF
--- a/src/react/components/instance-forms/ProductionForm.jsx
+++ b/src/react/components/instance-forms/ProductionForm.jsx
@@ -279,6 +279,41 @@ class ProductionForm extends Form {
 
 	}
 
+	renderProducerCredits (producerCredits) {
+
+		return (
+			<Fieldset header={'Producer team credits'}>
+
+				{
+					producerCredits.map((producerCredit, index) =>
+						<div className={'fieldset__module'} key={index}>
+
+							<ArrayItemRemovalButton
+								isRemovalButtonRequired={this.isRemovalButtonRequired(index, producerCredits.size)}
+								handleRemovalClick={event => this.handleRemovalClick(['producerCredits', index], event)}
+							/>
+
+							<FieldsetComponent label={'Name'} isArrayItem={true}>
+
+								<InputAndErrors
+									value={producerCredit.get('name')}
+									errors={producerCredit.getIn(['errors', 'name'])}
+									handleChange={event => this.handleChange(['producerCredits', index, 'name'], event)}
+								/>
+
+							</FieldsetComponent>
+
+							{ this.renderEntities(producerCredit.get('entities'), ['producerCredits', index, 'entities'], 'Producer') }
+
+						</div>
+					)
+				}
+
+			</Fieldset>
+		);
+
+	}
+
 	renderCreativeCredits (creativeCredits) {
 
 		return (
@@ -417,6 +452,8 @@ class ProductionForm extends Form {
 					</FieldsetComponent>
 
 				</Fieldset>
+
+				{ !!this.state.producerCredits && this.renderProducerCredits(this.state.producerCredits) }
 
 				{ !!this.state.cast && this.renderCast(this.state.cast) }
 


### PR DESCRIPTION
This PR adds functionality to be able to add/edit production producer credits as implemented in this API PR: https://github.com/andygout/theatrebase-api/pull/392.

It follows the same changes used to add crew credits: https://github.com/andygout/theatrebase-cms/pull/141.

---

#### Edit production form
<img width="924" alt="the-ladykillers-production-edit-form" src="https://user-images.githubusercontent.com/10484515/114751409-095c0400-9d4d-11eb-9d00-9c90d72847fc.png">