### PR TITLE
Replace arrays with sets where appropriate

### DIFF
--- a/src/lib/prune-instance.js
+++ b/src/lib/prune-instance.js
@@ -13,7 +13,7 @@ const pruneInstance = (instance, recursions = 0) => {
 
 		}
 
-		if (FORM_CONCEALED_KEYS.includes(key)) return accumulator;
+		if (FORM_CONCEALED_KEYS.has(key)) return accumulator;
 
 		if (isObjectWithKeys(instance[key])) {
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -8,12 +8,12 @@ const FORM_ACTIONS = {
 	update: 'UPDATE'
 };
 
-const FORM_CONCEALED_KEYS = [
+const FORM_CONCEALED_KEYS = new Set([
 	'model',
 	'uuid',
 	'errors',
 	'hasErrors'
-];
+]);
 
 const IRREGULAR_PLURAL_NOUNS_MAP = {
 	company: 'companies',


### PR DESCRIPTION
> The **`Set`** object lets you store unique values of any type, whether primitive values or object references.

> #### Description
> `Set` objects are collections of values. You can iterate through the elements of a set in insertion order. A value in the `Set` **may only occur once**; it is unique in the `Set`'s collection.

There are arrays in this repo whose values should always be unique, so this PR changes those to use sets instead.

### References:
- [MDN Web Docs: Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set)