### PR TITLE
Add production cast member role isAlternate checkbox

### DIFF
--- a/src/react/components/form/Form.jsx
+++ b/src/react/components/form/Form.jsx
@@ -51,7 +51,9 @@ class Form extends React.Component {
 
 	getNewStateForRootAttr (rootAttr, statePath, revision) {
 
-		let newStateForRootAttr = setIn(this.state[rootAttr], statePath, revision.value);
+		const revisionValue = revision.type === 'checkbox' ? revision.checked : revision.value;
+
+		let newStateForRootAttr = setIn(this.state[rootAttr], statePath, revisionValue);
 
 		if (revision.type !== 'text') return newStateForRootAttr;
 

--- a/src/react/components/instance-forms/ProductionForm.jsx
+++ b/src/react/components/instance-forms/ProductionForm.jsx
@@ -97,6 +97,16 @@ class ProductionForm extends Form {
 
 								</FieldsetComponent>
 
+								<FieldsetComponent label={'Alternate'} isArrayItem={true}>
+
+									<input
+										type="checkbox"
+										checked={role.get('isAlternate') || false}
+										onChange={event => this.handleChange(statePath.concat(['isAlternate']), event)}
+									/>
+
+								</FieldsetComponent>
+
 							</div>
 						);
 


### PR DESCRIPTION
This PR adds functionality to be able to add/edit production cast member role `isAlternate` property as implemented in this API PR: https://github.com/andygout/theatrebase-api/pull/431.

---

#### Edit production form
<img width="936" alt="edit-production-form" src="https://user-images.githubusercontent.com/10484515/123841857-fa2a3280-d907-11eb-8681-f9d9642d8d54.png">