### PR TITLE
Add award ceremony category nomination entities fieldset

### DIFF
--- a/src/lib/prune-instance.js
+++ b/src/lib/prune-instance.js
@@ -23,7 +23,9 @@ const pruneInstance = (instance, recursions = 0) => {
 
 			accumulator[key] =
 				instance[key]
-					.filter((item, index) => index === 0 || Boolean(item.name))
+					.filter((item, index) =>
+						index === 0 || !Object.prototype.hasOwnProperty.call(item, 'name') || Boolean(item.name)
+					)
 					.map(item => isObjectWithKeys(item) ? pruneInstance(item, recursions + 1) : item);
 
 		} else {

--- a/src/react/components/form/Form.jsx
+++ b/src/react/components/form/Form.jsx
@@ -1,11 +1,11 @@
-import { List, is, getIn, Map, removeIn, setIn, updateIn } from 'immutable';
+import { List, is, getIn, Map, remove, removeIn, set, setIn, updateIn } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Redirect } from 'react-router-dom';
 
 import createBlankMap from '../../../lib/create-blank-map';
 import mapHasNonEmptyString from '../../../lib/map-has-non-empty-string';
-import { ACTIONS, MODEL_TO_PROP_NAME_MAP } from '../../../utils/constants';
+import { ACTIONS, MODELS, MODEL_TO_PROP_NAME_MAP } from '../../../utils/constants';
 
 class Form extends React.Component {
 
@@ -125,6 +125,37 @@ class Form extends React.Component {
 		const rootAttr = statePath.shift();
 
 		this.setState({ [rootAttr]: removeIn(this.state[rootAttr], statePath) });
+
+	}
+
+	handleChangeToPerson (statePath, entity, property, event) {
+
+		let revisedEntity = entity;
+		revisedEntity = set(revisedEntity, 'model', event.target.value);
+		revisedEntity = remove(revisedEntity, property);
+
+		const revision = { value: revisedEntity, type: 'map' };
+
+		const rootAttr = statePath.shift();
+
+		this.setState({ [rootAttr]: this.applyRevisionToRootAttrState(this.state[rootAttr], statePath, revision) });
+
+	}
+
+	handleChangeToCompany (statePath, entity, property, event) {
+
+		const member = Map({ model: MODELS.PERSON, name: '', differentiator: '', errors: Map({}) });
+		const members = List([member]);
+
+		let revisedEntity = entity;
+		revisedEntity = set(revisedEntity, 'model', event.target.value);
+		revisedEntity = set(revisedEntity, property, members);
+
+		const revision = { value: revisedEntity, type: 'map' };
+
+		const rootAttr = statePath.shift();
+
+		this.setState({ [rootAttr]: this.applyRevisionToRootAttrState(this.state[rootAttr], statePath, revision) });
 
 	}
 

--- a/src/react/components/instance-forms/AwardCeremonyForm.jsx
+++ b/src/react/components/instance-forms/AwardCeremonyForm.jsx
@@ -5,8 +5,184 @@ import { connect } from 'react-redux';
 
 import { ArrayItemActionButton, Fieldset, FieldsetComponent, Form, FormWrapper, InputAndErrors } from '../form';
 import { createInstance, updateInstance, deleteInstance } from '../../../redux/actions/model';
+import { MODELS } from '../../../utils/constants';
 
 class AwardCeremonyForm extends Form {
+
+	renderNominatedMembers (nominatedMembers, nominatedMembersStatePath) {
+
+		return (
+			<FieldsetComponent label={'Nominated members (people)'} isArrayItem={true}>
+
+				{
+					nominatedMembers.map((nominatedMember, index) => {
+
+						const statePath = nominatedMembersStatePath.concat([index]);
+
+						const isLastListItem = this.isLastListItem(index, nominatedMembers.size);
+
+						return (
+							<div className={'fieldset__module fieldset__module--nested'} key={index}>
+
+								<ArrayItemActionButton
+									isLastListItem={isLastListItem}
+									handleClick={event =>
+										isLastListItem
+											? this.handleCreationClick(statePath, event)
+											: this.handleRemovalClick(statePath, event)
+									}
+								/>
+
+								<FieldsetComponent label={'Name'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={nominatedMember.get('name')}
+										errors={nominatedMember.getIn(['errors', 'name'])}
+										handleChange={event => this.handleChange(statePath.concat(['name']), event)}
+									/>
+
+								</FieldsetComponent>
+
+								<FieldsetComponent label={'Differentiator'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={nominatedMember.get('differentiator')}
+										errors={nominatedMember.getIn(['errors', 'differentiator'])}
+										handleChange={event => this.handleChange(statePath.concat(['differentiator']), event)}
+									/>
+
+								</FieldsetComponent>
+
+							</div>
+						);
+
+					})
+				}
+
+			</FieldsetComponent>
+		);
+
+	}
+
+	renderEntities (entities, entitiesStatePath) {
+
+		return (
+			<FieldsetComponent label={'Nominees (people, companies)'} isArrayItem={true}>
+
+				{
+					entities.map((entity, index) => {
+
+						const statePath = entitiesStatePath.concat([index]);
+
+						const isLastListItem = this.isLastListItem(index, entities.size);
+
+						return (
+							<div className={'fieldset__module fieldset__module--nested'} key={index}>
+
+								<ArrayItemActionButton
+									isLastListItem={isLastListItem}
+									handleClick={event =>
+										isLastListItem
+											? this.handleCreationClick(statePath, event)
+											: this.handleRemovalClick(statePath, event)
+									}
+								/>
+
+								<FieldsetComponent label={'Name'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={entity.get('name')}
+										errors={entity.getIn(['errors', 'name'])}
+										handleChange={event => this.handleChange(statePath.concat(['name']), event)}
+									/>
+
+								</FieldsetComponent>
+
+								<FieldsetComponent label={'Differentiator'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={entity.get('differentiator')}
+										errors={entity.getIn(['errors', 'differentiator'])}
+										handleChange={event => this.handleChange(statePath.concat(['differentiator']), event)}
+									/>
+
+								</FieldsetComponent>
+
+								<FieldsetComponent label={'Model'} isArrayItem={true}>
+
+									<input
+										type={'radio'}
+										value={MODELS.PERSON}
+										checked={entity.get('model') === MODELS.PERSON}
+										onChange={event => this.handleChangeToPerson(statePath, entity, 'nominatedMembers', event)}
+									/>
+									<label>&nbsp;Person</label>
+
+									<input
+										type={'radio'}
+										value={MODELS.COMPANY}
+										checked={entity.get('model') === MODELS.COMPANY}
+										onChange={event => this.handleChangeToCompany(statePath, entity, 'nominatedMembers', event)}
+									/>
+									<label>&nbsp;Company</label>
+
+								</FieldsetComponent>
+
+								{
+									entity.get('model') === MODELS.COMPANY &&
+									this.renderNominatedMembers(
+										entity.get('nominatedMembers', []),
+										statePath.concat(['nominatedMembers'])
+									)
+								}
+
+							</div>
+						);
+
+					})
+				}
+
+			</FieldsetComponent>
+		);
+
+	}
+
+	renderNominations (nominations, nominationsStatePath) {
+
+		return (
+			<FieldsetComponent label={'Nominations'} isArrayItem={true}>
+
+				{
+					nominations.map((nomination, index) => {
+
+						const statePath = nominationsStatePath.concat([index]);
+
+						const isLastListItem = this.isLastListItem(index, nominations.size);
+
+						return (
+							<div className={'fieldset__module fieldset__module--nested'} key={index}>
+
+								<ArrayItemActionButton
+									isLastListItem={isLastListItem}
+									handleClick={event =>
+										isLastListItem
+											? this.handleCreationClick(statePath, event)
+											: this.handleRemovalClick(statePath, event)
+									}
+								/>
+
+								{ this.renderEntities(nomination.get('entities'), statePath.concat('entities')) }
+
+							</div>
+						);
+
+					})
+				}
+
+			</FieldsetComponent>
+		);
+
+	}
 
 	renderCategories (categories) {
 
@@ -41,6 +217,8 @@ class AwardCeremonyForm extends Form {
 									/>
 
 								</FieldsetComponent>
+
+								{ this.renderNominations(category.get('nominations'), statePath.concat(['nominations'])) }
 
 							</div>
 						);

--- a/src/react/components/instance-forms/ProductionForm.jsx
+++ b/src/react/components/instance-forms/ProductionForm.jsx
@@ -1,4 +1,4 @@
-import { List, Map, remove, set } from 'immutable';
+import { Map } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -8,37 +8,6 @@ import { createInstance, updateInstance, deleteInstance } from '../../../redux/a
 import { MODELS } from '../../../utils/constants';
 
 class ProductionForm extends Form {
-
-	handleChangeToPerson (statePath, entity, event) {
-
-		let revisedEntity = entity;
-		revisedEntity = set(revisedEntity, 'model', event.target.value);
-		revisedEntity = remove(revisedEntity, 'creditedMembers');
-
-		const revision = { value: revisedEntity, type: 'map' };
-
-		const rootAttr = statePath.shift();
-
-		this.setState({ [rootAttr]: this.applyRevisionToRootAttrState(this.state[rootAttr], statePath, revision) });
-
-	}
-
-	handleChangeToCompany (statePath, entity, event) {
-
-		const creditedMember = Map({ model: MODELS.PERSON, name: '', differentiator: '', errors: Map({}) });
-		const creditedMembers = List([creditedMember]);
-
-		let revisedEntity = entity;
-		revisedEntity = set(revisedEntity, 'model', event.target.value);
-		revisedEntity = set(revisedEntity, 'creditedMembers', creditedMembers);
-
-		const revision = { value: revisedEntity, type: 'map' };
-
-		const rootAttr = statePath.shift();
-
-		this.setState({ [rootAttr]: this.applyRevisionToRootAttrState(this.state[rootAttr], statePath, revision) });
-
-	}
 
 	renderCastMemberRoles (roles, rolesStatePath) {
 
@@ -287,7 +256,7 @@ class ProductionForm extends Form {
 										type={'radio'}
 										value={MODELS.PERSON}
 										checked={entity.get('model') === MODELS.PERSON}
-										onChange={event => this.handleChangeToPerson(statePath, entity, event)}
+										onChange={event => this.handleChangeToPerson(statePath, entity, 'creditedMembers', event)}
 									/>
 									<label>&nbsp;Person</label>
 
@@ -295,7 +264,7 @@ class ProductionForm extends Form {
 										type={'radio'}
 										value={MODELS.COMPANY}
 										checked={entity.get('model') === MODELS.COMPANY}
-										onChange={event => this.handleChangeToCompany(statePath, entity, event)}
+										onChange={event => this.handleChangeToCompany(statePath, entity, 'creditedMembers', event)}
 									/>
 									<label>&nbsp;Company</label>
 

--- a/test/src/lib/prune-instance.test.js
+++ b/test/src/lib/prune-instance.test.js
@@ -183,6 +183,64 @@ describe('prune Instance module', () => {
 
 	});
 
+	it('retains array items that do not have name property', () => {
+
+		const instance = {
+			name: '2019',
+			categories: [
+				{
+					name: 'Best Actor',
+					nominations: [
+						{
+							entities: [
+								{
+									name: 'Ian McKellen'
+								}
+							]
+						},
+						{
+							entities: [
+								{
+									name: 'David Suchet'
+								}
+							]
+						}
+					]
+				}
+			]
+		};
+
+		const result = pruneInstance(instance);
+
+		const expectation = {
+			name: '2019',
+			categories: [
+				{
+					name: 'Best Actor',
+					nominations: [
+						{
+							entities: [
+								{
+									name: 'Ian McKellen'
+								}
+							]
+						},
+						{
+							entities: [
+								{
+									name: 'David Suchet'
+								}
+							]
+						}
+					]
+				}
+			]
+		};
+
+		expect(result).to.deep.equal(expectation);
+
+	});
+
 	it('prunes a sample instance as per specification', () => {
 
 		const instance = {


### PR DESCRIPTION
This PR adds functionality to be able to add/edit award ceremony category nomination entities as implemented in this API PR: https://github.com/andygout/theatrebase-api/pull/448.

---

#### Edit award ceremony form
<img width="838" alt="edit-award-ceremony-form" src="https://user-images.githubusercontent.com/10484515/141333542-a1efae29-d226-4c93-9f94-d130726d96b2.png">