### PR TITLE
Revise role isAlternate property handling

### DIFF
--- a/src/react/components/instance-forms/ProductionForm.jsx
+++ b/src/react/components/instance-forms/ProductionForm.jsx
@@ -77,7 +77,7 @@ class ProductionForm extends Form {
 
 									<input
 										type="checkbox"
-										checked={role.get('isAlternate') || false}
+										checked={role.get('isAlternate')}
 										onChange={event => this.handleChange(statePath.concat(['isAlternate']), event)}
 									/>
 


### PR DESCRIPTION
Changes made in this API PR https://github.com/andygout/theatrebase-api/pull/453 mean that the non-true value returned for the role `isAlternate` property will be `false` rather than `null` and so the default `false` value is no longer required.