### PR TITLE
Add award ceremony category nomination productions fieldset

### DIFF
--- a/src/lib/prune-instance.js
+++ b/src/lib/prune-instance.js
@@ -26,6 +26,9 @@ const pruneInstance = (instance, recursions = 0) => {
 					.filter((item, index) =>
 						index === 0 || !Object.prototype.hasOwnProperty.call(item, 'name') || Boolean(item.name)
 					)
+					.filter((item, index) =>
+						index === 0 || !Object.prototype.hasOwnProperty.call(item, 'uuid') || Boolean(item.uuid)
+					)
 					.map(item => isObjectWithKeys(item) ? pruneInstance(item, recursions + 1) : item);
 
 		} else {

--- a/src/react/components/instance-forms/AwardCeremonyForm.jsx
+++ b/src/react/components/instance-forms/AwardCeremonyForm.jsx
@@ -64,10 +64,55 @@ class AwardCeremonyForm extends Form {
 
 	}
 
+	renderProductions (productions, productionsStatePath) {
+
+		return (
+			<FieldsetComponent label={'Nominated productions'} isArrayItem={true}>
+
+				{
+					productions.map((production, index) => {
+
+						const statePath = productionsStatePath.concat([index]);
+
+						const isLastListItem = this.isLastListItem(index, productions.size);
+
+						return (
+							<div className={'fieldset__module fieldset__module--nested'} key={index}>
+
+								<ArrayItemActionButton
+									isLastListItem={isLastListItem}
+									handleClick={event =>
+										isLastListItem
+											? this.handleCreationClick(statePath, event)
+											: this.handleRemovalClick(statePath, event)
+									}
+								/>
+
+								<FieldsetComponent label={'UUID'} isArrayItem={true}>
+
+									<InputAndErrors
+										value={production.get('uuid')}
+										errors={production.getIn(['errors', 'uuid'])}
+										handleChange={event => this.handleChange(statePath.concat(['uuid']), event)}
+									/>
+
+								</FieldsetComponent>
+
+							</div>
+						);
+
+					})
+				}
+
+			</FieldsetComponent>
+		);
+
+	}
+
 	renderEntities (entities, entitiesStatePath) {
 
 		return (
-			<FieldsetComponent label={'Nominees (people, companies)'} isArrayItem={true}>
+			<FieldsetComponent label={'Nominated entities (people, companies)'} isArrayItem={true}>
 
 				{
 					entities.map((entity, index) => {
@@ -179,6 +224,8 @@ class AwardCeremonyForm extends Form {
 								/>
 
 								{ this.renderEntities(nomination.get('entities'), statePath.concat('entities')) }
+
+								{ this.renderProductions(nomination.get('productions'), statePath.concat('productions')) }
 
 							</div>
 						);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -27,7 +27,6 @@ const CREDIT_TYPES = {
 
 const FORM_CONCEALED_KEYS = new Set([
 	'model',
-	'uuid',
 	'errors',
 	'hasErrors'
 ]);

--- a/test/src/lib/prune-instance.test.js
+++ b/test/src/lib/prune-instance.test.js
@@ -4,12 +4,11 @@ import pruneInstance from '../../../src/lib/prune-instance';
 
 describe('prune Instance module', () => {
 
-	it('removes top-level concealed attributes (e.g. \'errors\', and \'uuid\')', () => {
+	it('removes top-level concealed attributes (e.g. \'errors\')', () => {
 
 		const instance = {
 			name: 'King Lear',
-			errors: {},
-			uuid: 'b22157c0-4ecd-4bd9-b4fd-2656d3def80e'
+			errors: {}
 		};
 
 		const result = pruneInstance(instance);
@@ -22,18 +21,20 @@ describe('prune Instance module', () => {
 
 	});
 
-	it('retains top-level \'model\' attribute', () => {
+	it('retains top-level \'model\' and \'uuid\' attributes', () => {
 
 		const instance = {
 			name: 'King Lear',
-			model: 'PRODUCTION'
+			model: 'PRODUCTION',
+			uuid: 'b22157c0-4ecd-4bd9-b4fd-2656d3def80e'
 		};
 
 		const result = pruneInstance(instance);
 
 		const expectation = {
 			name: 'King Lear',
-			model: 'PRODUCTION'
+			model: 'PRODUCTION',
+			uuid: 'b22157c0-4ecd-4bd9-b4fd-2656d3def80e'
 		};
 
 		expect(result).to.deep.equal(expectation);
@@ -183,7 +184,74 @@ describe('prune Instance module', () => {
 
 	});
 
-	it('retains array items that do not have name property', () => {
+	describe('filters out array items that have empty string uuid', () => {
+
+		context('array items with non-empty strings exist', () => {
+
+			it('filters out array items that have empty string uuid values', () => {
+
+				const instance = {
+					name: '2020',
+					productions: [
+						{
+							uuid: 'b22157c0-4ecd-4bd9-b4fd-2656d3def80e'
+						},
+						{
+							uuid: ''
+						}
+					]
+				};
+
+				const result = pruneInstance(instance);
+
+				const expectation = {
+					name: '2020',
+					productions: [
+						{
+							uuid: 'b22157c0-4ecd-4bd9-b4fd-2656d3def80e'
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectation);
+
+			});
+
+		});
+
+		context('array items with non-empty strings do not exist', () => {
+
+			it('leaves single array item that has empty string name value', () => {
+
+				const instance = {
+					name: '2020',
+					productions: [
+						{
+							uuid: ''
+						}
+					]
+				};
+
+				const result = pruneInstance(instance);
+
+				const expectation = {
+					name: '2020',
+					productions: [
+						{
+							uuid: ''
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectation);
+
+			});
+
+		});
+
+	});
+
+	it('retains array items that do not have name or uuid property (i.e. each item in nominations array)', () => {
 
 		const instance = {
 			name: '2019',
@@ -241,7 +309,7 @@ describe('prune Instance module', () => {
 
 	});
 
-	it('prunes a sample instance as per specification', () => {
+	it('prunes a sample production instance as per specification', () => {
 
 		const instance = {
 			name: 'King Lear',
@@ -300,6 +368,7 @@ describe('prune Instance module', () => {
 		const expectation = {
 			name: 'King Lear',
 			model: 'PRODUCTION',
+			uuid: 'b22157c0-4ecd-4bd9-b4fd-2656d3def80e',
 			venue: {
 				name: 'Courtyard Theatre'
 			},
@@ -314,6 +383,90 @@ describe('prune Instance module', () => {
 						{
 							name: 'King Lear',
 							characterName: ''
+						}
+					]
+				}
+			]
+		};
+
+		expect(result).to.deep.equal(expectation);
+
+	});
+
+	it('prunes a sample award ceremony instance as per specification', () => {
+
+		const instance = {
+			model: 'AWARD_CEREMONY',
+			name: '',
+			errors: {},
+			award: {
+				model: 'AWARD',
+				name: '',
+				errors: {},
+				differentiator: ''
+			},
+			categories: [
+				{
+					model: 'AWARD_CEREMONY_CATEGORY',
+					name: '',
+					errors: {},
+					nominations: [
+						{
+							model: 'NOMINATION',
+							errors: {},
+							isWinner: false,
+							entities: [
+								{
+									model: 'PERSON',
+									name: '',
+									errors: {},
+									differentiator: ''
+								}
+							],
+							productions: [
+								{
+									model: 'PRODUCTION_IDENTIFIER',
+									errors: {},
+									uuid: 'b22157c0-4ecd-4bd9-b4fd-2656d3def80e'
+								},
+								{
+									model: 'PRODUCTION_IDENTIFIER',
+									errors: {},
+									uuid: ''
+								}
+							]
+						}
+					]
+				}
+			]
+		};
+
+		const result = pruneInstance(instance);
+
+		const expectation = {
+			model: 'AWARD_CEREMONY',
+			name: '',
+			award: {
+				name: '',
+				differentiator: ''
+			},
+			categories: [
+				{
+					name: '',
+					nominations: [
+						{
+							isWinner: false,
+							entities: [
+								{
+									name: '',
+									differentiator: ''
+								}
+							],
+							productions: [
+								{
+									uuid: 'b22157c0-4ecd-4bd9-b4fd-2656d3def80e'
+								}
+							]
 						}
 					]
 				}


### PR DESCRIPTION
This PR adds functionality to be able to add/edit award ceremony category nomination productions as implemented in this API PR: https://github.com/andygout/theatrebase-api/pull/458.

---

#### Edit award ceremony form
<img width="692" alt="edit-award-ceremony-form" src="https://user-images.githubusercontent.com/10484515/145675980-fed45b7d-31b2-49d0-a809-413eeb03277a.png">