### PR TITLE
Revise fieldset component labels

### DIFF
--- a/src/react/components/instance-forms/AwardCeremonyForm.jsx
+++ b/src/react/components/instance-forms/AwardCeremonyForm.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
+import { capitalise } from '../../../lib/strings';
 import { ArrayItemActionButton, Fieldset, FieldsetComponent, Form, FormWrapper, InputAndErrors } from '../form';
 import { createInstance, updateInstance, deleteInstance } from '../../../redux/actions/model';
 import { MODELS } from '../../../utils/constants';
@@ -12,7 +13,7 @@ class AwardCeremonyForm extends Form {
 	renderMembers (members, membersStatePath) {
 
 		return (
-			<FieldsetComponent label={'Nominated members (people)'} isArrayItem={true}>
+			<FieldsetComponent label={'Nominated company members (people)'} isArrayItem={true}>
 
 				{
 					members.map((member, index) => {
@@ -33,7 +34,7 @@ class AwardCeremonyForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={'Person name'} isArrayItem={true}>
 
 									<InputAndErrors
 										value={member.get('name')}
@@ -88,7 +89,7 @@ class AwardCeremonyForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={'Material name'} isArrayItem={true}>
 
 									<InputAndErrors
 										value={material.get('name')}
@@ -143,7 +144,7 @@ class AwardCeremonyForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'UUID'} isArrayItem={true}>
+								<FieldsetComponent label={'Production UUID'} isArrayItem={true}>
 
 									<InputAndErrors
 										value={production.get('uuid')}
@@ -188,7 +189,7 @@ class AwardCeremonyForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={`${capitalise(entity.get('model'))} name`} isArrayItem={true}>
 
 									<InputAndErrors
 										value={entity.get('name')}
@@ -319,7 +320,7 @@ class AwardCeremonyForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={'Category name'} isArrayItem={true}>
 
 									<InputAndErrors
 										value={category.get('name')}

--- a/src/react/components/instance-forms/MaterialForm.jsx
+++ b/src/react/components/instance-forms/MaterialForm.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
+import { capitalise } from '../../../lib/strings';
 import { ArrayItemActionButton, Fieldset, FieldsetComponent, Form, FormWrapper, InputAndErrors } from '../form';
 import { createInstance, updateInstance, deleteInstance } from '../../../redux/actions/model';
 import { CREDIT_TYPES, MODELS } from '../../../utils/constants';
@@ -33,7 +34,7 @@ class MaterialForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={`${capitalise(entity.get('model'))} name`} isArrayItem={true}>
 
 									<InputAndErrors
 										value={entity.get('name')}
@@ -116,7 +117,7 @@ class MaterialForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={'Credit name'} isArrayItem={true}>
 
 									<InputAndErrors
 										value={writingCredit.get('name')}
@@ -191,7 +192,7 @@ class MaterialForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={'Character name'} isArrayItem={true}>
 
 									<InputAndErrors
 										value={character.get('name')}
@@ -266,7 +267,7 @@ class MaterialForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={'Group name'} isArrayItem={true}>
 
 									<InputAndErrors
 										value={characterGroup.get('name')}

--- a/src/react/components/instance-forms/ProductionForm.jsx
+++ b/src/react/components/instance-forms/ProductionForm.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
+import { capitalise } from '../../../lib/strings';
 import { ArrayItemActionButton, Fieldset, FieldsetComponent, Form, FormWrapper, InputAndErrors } from '../form';
 import { createInstance, updateInstance, deleteInstance } from '../../../redux/actions/model';
 import { MODELS } from '../../../utils/constants';
@@ -33,7 +34,7 @@ class ProductionForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={'Role name'} isArrayItem={true}>
 
 									<InputAndErrors
 										value={role.get('name')}
@@ -118,7 +119,7 @@ class ProductionForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={'Person name'} isArrayItem={true}>
 
 									<InputAndErrors
 										value={castMember.get('name')}
@@ -154,7 +155,7 @@ class ProductionForm extends Form {
 	renderMembers (members, membersStatePath) {
 
 		return (
-			<FieldsetComponent label={'Credited members (people)'} isArrayItem={true}>
+			<FieldsetComponent label={'Credited company members (people)'} isArrayItem={true}>
 
 				{
 					members.map((member, index) => {
@@ -175,7 +176,7 @@ class ProductionForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={'Person name'} isArrayItem={true}>
 
 									<InputAndErrors
 										value={member.get('name')}
@@ -230,7 +231,7 @@ class ProductionForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={`${capitalise(entity.get('model'))} name`} isArrayItem={true}>
 
 									<InputAndErrors
 										value={entity.get('name')}
@@ -310,7 +311,7 @@ class ProductionForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={'Credit name'} isArrayItem={true}>
 
 									<InputAndErrors
 										value={producerCredit.get('name')}
@@ -357,7 +358,7 @@ class ProductionForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={'Credit name'} isArrayItem={true}>
 
 									<InputAndErrors
 										value={creativeCredit.get('name')}
@@ -404,7 +405,7 @@ class ProductionForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={'Credit name'} isArrayItem={true}>
 
 									<InputAndErrors
 										value={crewCredit.get('name')}

--- a/src/react/components/instance-forms/VenueForm.jsx
+++ b/src/react/components/instance-forms/VenueForm.jsx
@@ -32,7 +32,7 @@ class VenueForm extends Form {
 									}
 								/>
 
-								<FieldsetComponent label={'Name'} isArrayItem={true}>
+								<FieldsetComponent label={'Venue name'} isArrayItem={true}>
 
 									<InputAndErrors
 										value={subVenue.get('name')}


### PR DESCRIPTION
This PR revises the labels of the fieldset components to make them clearer given the nesting of components within components can sometimes make it hard to follow exactly which label applies to which field, e.g.
- **Name** -> **Credit name**
- **Name** -> **Person name**
- **Name** -> **Company name**
- **Credited members (people)** -> **Credited company members (people)**

#### Before
<img width="915" alt="before" src="https://user-images.githubusercontent.com/10484515/149412632-86903e5a-239c-48d4-ad41-fcbfcac32c36.png">

#### After
<img width="917" alt="after" src="https://user-images.githubusercontent.com/10484515/149412651-84579cc4-513e-429e-9cf5-cbc31e151fe5.png">