### PR TITLE
Retain property order for displayed JSON objects

### DIFF
--- a/src/redux/reducers/award-ceremony.js
+++ b/src/redux/reducers/award-ceremony.js
@@ -1,4 +1,4 @@
-import { Map, fromJS } from 'immutable';
+import { Map, OrderedMap } from 'immutable';
 
 import {
 	REQUEST_AWARD_CEREMONY,
@@ -19,7 +19,7 @@ const awardCeremony = (state = Map(), action) => {
 		case RECEIVE_AWARD_CEREMONY_CREATE:
 		case RECEIVE_AWARD_CEREMONY_UPDATE:
 		case RECEIVE_AWARD_CEREMONY_DELETE:
-			return fromJS(action.payload);
+			return OrderedMap(action.payload);
 
 		case REQUEST_AWARD_CEREMONY:
 		case REQUEST_AWARD_CEREMONY_CREATE:

--- a/src/redux/reducers/award.js
+++ b/src/redux/reducers/award.js
@@ -1,4 +1,4 @@
-import { Map, fromJS } from 'immutable';
+import { Map, OrderedMap } from 'immutable';
 
 import {
 	REQUEST_AWARD,
@@ -19,7 +19,7 @@ const award = (state = Map(), action) => {
 		case RECEIVE_AWARD_CREATE:
 		case RECEIVE_AWARD_UPDATE:
 		case RECEIVE_AWARD_DELETE:
-			return fromJS(action.payload);
+			return OrderedMap(action.payload);
 
 		case REQUEST_AWARD:
 		case REQUEST_AWARD_CREATE:

--- a/src/redux/reducers/character.js
+++ b/src/redux/reducers/character.js
@@ -1,4 +1,4 @@
-import { Map, fromJS } from 'immutable';
+import { Map, OrderedMap } from 'immutable';
 
 import {
 	REQUEST_CHARACTER,
@@ -19,7 +19,7 @@ const character = (state = Map(), action) => {
 		case RECEIVE_CHARACTER_CREATE:
 		case RECEIVE_CHARACTER_UPDATE:
 		case RECEIVE_CHARACTER_DELETE:
-			return fromJS(action.payload);
+			return OrderedMap(action.payload);
 
 		case REQUEST_CHARACTER:
 		case REQUEST_CHARACTER_CREATE:

--- a/src/redux/reducers/company.js
+++ b/src/redux/reducers/company.js
@@ -1,4 +1,4 @@
-import { Map, fromJS } from 'immutable';
+import { Map, OrderedMap } from 'immutable';
 
 import {
 	REQUEST_COMPANY,
@@ -19,7 +19,7 @@ const company = (state = Map(), action) => {
 		case RECEIVE_COMPANY_CREATE:
 		case RECEIVE_COMPANY_UPDATE:
 		case RECEIVE_COMPANY_DELETE:
-			return fromJS(action.payload);
+			return OrderedMap(action.payload);
 
 		case REQUEST_COMPANY:
 		case REQUEST_COMPANY_CREATE:

--- a/src/redux/reducers/material.js
+++ b/src/redux/reducers/material.js
@@ -1,4 +1,4 @@
-import { Map, fromJS } from 'immutable';
+import { Map, OrderedMap } from 'immutable';
 
 import {
 	REQUEST_MATERIAL,
@@ -19,7 +19,7 @@ const material = (state = Map(), action) => {
 		case RECEIVE_MATERIAL_CREATE:
 		case RECEIVE_MATERIAL_UPDATE:
 		case RECEIVE_MATERIAL_DELETE:
-			return fromJS(action.payload);
+			return OrderedMap(action.payload);
 
 		case REQUEST_MATERIAL:
 		case REQUEST_MATERIAL_CREATE:

--- a/src/redux/reducers/person.js
+++ b/src/redux/reducers/person.js
@@ -1,4 +1,4 @@
-import { Map, fromJS } from 'immutable';
+import { Map, OrderedMap } from 'immutable';
 
 import {
 	REQUEST_PERSON,
@@ -19,7 +19,7 @@ const person = (state = Map(), action) => {
 		case RECEIVE_PERSON_CREATE:
 		case RECEIVE_PERSON_UPDATE:
 		case RECEIVE_PERSON_DELETE:
-			return fromJS(action.payload);
+			return OrderedMap(action.payload);
 
 		case REQUEST_PERSON:
 		case REQUEST_PERSON_CREATE:

--- a/src/redux/reducers/production.js
+++ b/src/redux/reducers/production.js
@@ -1,4 +1,4 @@
-import { Map, fromJS } from 'immutable';
+import { Map, OrderedMap } from 'immutable';
 
 import {
 	REQUEST_PRODUCTION,
@@ -19,7 +19,7 @@ const production = (state = Map(), action) => {
 		case RECEIVE_PRODUCTION_CREATE:
 		case RECEIVE_PRODUCTION_UPDATE:
 		case RECEIVE_PRODUCTION_DELETE:
-			return fromJS(action.payload);
+			return OrderedMap(action.payload);
 
 		case REQUEST_PRODUCTION:
 		case REQUEST_PRODUCTION_CREATE:

--- a/src/redux/reducers/venue.js
+++ b/src/redux/reducers/venue.js
@@ -1,4 +1,4 @@
-import { Map, fromJS } from 'immutable';
+import { Map, OrderedMap } from 'immutable';
 
 import {
 	REQUEST_VENUE,
@@ -19,7 +19,7 @@ const venue = (state = Map(), action) => {
 		case RECEIVE_VENUE_CREATE:
 		case RECEIVE_VENUE_UPDATE:
 		case RECEIVE_VENUE_DELETE:
-			return fromJS(action.payload);
+			return OrderedMap(action.payload);
 
 		case REQUEST_VENUE:
 		case REQUEST_VENUE_CREATE:


### PR DESCRIPTION
Uses an `Immutable` `OrderedMap` to preserve the order of instance properties when displaying them as JSON objects on their respective edit pages so that the order is consistent and corresponds with the order of the fields in the form.

Unfortunately there did not seem to be an easy way of preserving the order of instance properties for each item on the list pages (if `OrderedMap`s are passed as an argument to Immutable's `fromJS()` or `List()` then the end result is the order being disregarded (i.e. behaving like a `Map` rather than an `OrderedMap`)).

#### Before
<img width="468" alt="before" src="https://user-images.githubusercontent.com/10484515/149415124-0cdb71c6-9bac-44c8-8dc4-453af50b0b21.png">

#### After
<img width="461" alt="after" src="https://user-images.githubusercontent.com/10484515/149415143-ea260255-bfaf-46ae-9195-4afde5c709a0.png">

### References:
- [Stack Overflow: Avoid sorting using immutable.js](https://stackoverflow.com/questions/39840039/avoid-sorting-using-immutable-js#answer-40241562)
- [Immutable.js: OrderedMap](https://immutable-js.com/docs/v3.8.2/OrderedMap)