### PR TITLE
Add award ceremony category nomination customType fieldset

### DIFF
--- a/src/react/components/instance-forms/AwardCeremonyForm.jsx
+++ b/src/react/components/instance-forms/AwardCeremonyForm.jsx
@@ -270,6 +270,16 @@ class AwardCeremonyForm extends Form {
 
 								</FieldsetComponent>
 
+								<FieldsetComponent label={'Custom type'}>
+
+									<InputAndErrors
+										value={nomination.get('customType')}
+										errors={nomination.getIn(['errors', 'customType'])}
+										handleChange={event => this.handleChange(statePath.concat(['customType']), event)}
+									/>
+
+								</FieldsetComponent>
+
 								<ArrayItemActionButton
 									isLastListItem={isLastListItem}
 									handleClick={event =>


### PR DESCRIPTION
This PR adds functionality to be able to add/edit award ceremony category nomination customType as implemented in this API PR: https://github.com/andygout/theatrebase-api/pull/480.

---

#### Edit award ceremony form
<img width="930" alt="edit-award-ceremony-form" src="https://user-images.githubusercontent.com/10484515/162006197-e889b4cb-9027-4a49-94b0-a5f407a91419.png">