### PR TITLE
Sass migration

### DIFF
--- a/src/client/stylesheets/_footer.scss
+++ b/src/client/stylesheets/_footer.scss
@@ -1,6 +1,8 @@
+@use 'lib/color-variables';
+
 .footer {
 	height: 20px;
-	background-color: $header-background-color;
+	background-color: color-variables.$header-background-color;
 	font-weight: bold;
 }
 
@@ -8,7 +10,7 @@
 	margin-top: 4px;
 	padding: 0 10px;
 	font-size: x-small;
-	color: $header-text-color;
+	color: color-variables.$header-text-color;
 }
 
 .footer__text--left {

--- a/src/client/stylesheets/_form.scss
+++ b/src/client/stylesheets/_form.scss
@@ -1,3 +1,5 @@
+@use 'lib/color-variables';
+
 $action-button-height: 18px;
 
 .form {
@@ -6,8 +8,8 @@ $action-button-height: 18px;
 
 .fieldset {
 	padding: 10px 10px 20px;
-	background-color: $form-background-color;
-	border: 2px solid $border-color;
+	background-color: color-variables.$form-background-color;
+	border: 2px solid color-variables.$border-color;
 	border-radius: 5px;
 }
 
@@ -27,7 +29,7 @@ $action-button-height: 18px;
 .fieldset__module {
 	padding: 5px;
 	margin-bottom: 5px;
-	border: 1px dashed $border-color;
+	border: 1px dashed color-variables.$border-color;
 	border-radius: 5px;
 }
 
@@ -49,14 +51,14 @@ $action-button-height: 18px;
 	height: $action-button-height;
 	width: 36px;
 	line-height: $action-button-height;
-	color: $theme-color;
-	background-color: $content-background-color;
-	border: 1px solid $border-color;
+	color: color-variables.$theme-color;
+	background-color: color-variables.$content-background-color;
+	border: 1px solid color-variables.$border-color;
 	border-radius: 5px;
 	cursor: pointer;
 
 	&:hover {
-		color: $default-text-color;
+		color: color-variables.$default-text-color;
 	}
 }
 
@@ -69,19 +71,19 @@ $action-button-height: 18px;
 	width: 100%;
 
 	&--has-errors {
-		border-color: $error-color;
+		border-color: color-variables.$error-color;
 	}
 }
 
 .field__error-list-item {
 	list-style: disc inside none;
-	color: $error-color;
+	color: color-variables.$error-color;
 }
 
 .button {
 	margin-top: 40px;
 	height: 22px;
 	width: 170px;
-	background-color: $button-background-color;
+	background-color: color-variables.$button-background-color;
 	cursor: pointer;
 }

--- a/src/client/stylesheets/_header.scss
+++ b/src/client/stylesheets/_header.scss
@@ -1,15 +1,17 @@
+@use 'lib/color-variables';
+
 .header {
-	background-color: $header-background-color;
+	background-color: color-variables.$header-background-color;
 	padding: 0 10px;
 }
 
 .header__home-link {
 	font-size: 65px;
 	font-weight: bold;
-	color: $header-text-color;
+	color: color-variables.$header-text-color;
 	transition: color 0.5s;
 
 	&:hover {
-		color: $header-text-color-hover;
+		color: color-variables.$header-text-color-hover;
 	}
 }

--- a/src/client/stylesheets/_instance.scss
+++ b/src/client/stylesheets/_instance.scss
@@ -1,10 +1,12 @@
+@use 'lib/color-variables';
+
 .instance-label {
 	margin-bottom: 20px;
 	padding: 0 5px;
 	display: inline-block;
 	border-radius: 2px;
-	border: 2px solid $border-color;
-	background-color: $box-shadow-color;
+	border: 2px solid color-variables.$border-color;
+	background-color: color-variables.$box-shadow-color;
 	font-weight: bold;
 	text-transform: uppercase;
 }

--- a/src/client/stylesheets/_notification.scss
+++ b/src/client/stylesheets/_notification.scss
@@ -1,3 +1,5 @@
+@use 'lib/color-variables';
+
 .notification {
 	position: fixed;
 	top: 10px;
@@ -6,13 +8,13 @@
 	padding: 20px;
 	max-width: 500px;
 	border-radius: 5px;
-	border: 2px solid $border-color;
+	border: 2px solid color-variables.$border-color;
 }
 
 .notification--success {
-	background-color: $success-color;
+	background-color: color-variables.$success-color;
 }
 
 .notification--failure {
-	background-color: $failure-color;
+	background-color: color-variables.$failure-color;
 }

--- a/src/client/stylesheets/_page.scss
+++ b/src/client/stylesheets/_page.scss
@@ -1,15 +1,17 @@
+@use 'lib/color-variables';
+
 * {
 	margin: 0;
 	padding: 0;
 	font-family: arial, sans-serif;
-	color: $default-text-color;
+	color: color-variables.$default-text-color;
 	text-decoration: none;
 }
 
 html {
 	height: 100%;
 	text-align: center;
-	background-color: $html-background-color;
+	background-color: color-variables.$html-background-color;
 }
 
 body {
@@ -19,10 +21,10 @@ body {
 }
 
 a {
-	color: $theme-color;
+	color: color-variables.$theme-color;
 
 	&:hover {
-		color: $default-text-color;
+		color: color-variables.$default-text-color;
 	}
 }
 
@@ -32,11 +34,11 @@ a {
 	margin: 0 auto;
 	width: 1000px;
 	flex-direction: column;
-	background-color: $content-background-color;
-	border-left: solid $border-color;
-	border-right: solid $border-color;
+	background-color: color-variables.$content-background-color;
+	border-left: solid color-variables.$border-color;
+	border-right: solid color-variables.$border-color;
 	border-width: 0 2px 2px;
-	box-shadow:  5px 5px 100px $border-color, 5px 5px 100px $box-shadow-color;
+	box-shadow:  5px 5px 100px color-variables.$border-color, 5px 5px 100px color-variables.$box-shadow-color;
 	text-align: left;
 }
 

--- a/src/client/stylesheets/_text.scss
+++ b/src/client/stylesheets/_text.scss
@@ -1,10 +1,12 @@
+@use 'lib/color-variables';
+
 .title-text {
 	margin: 0 5px 20px 5px;
 	padding-bottom: 0px;
 	font-size: xx-large;
-	color: $theme-color;
+	color: color-variables.$theme-color;
 }
 
 .title-text--muted {
-	color: $default-text-color;
+	color: color-variables.$default-text-color;
 }

--- a/src/client/stylesheets/index.scss
+++ b/src/client/stylesheets/index.scss
@@ -1,12 +1,12 @@
-@import 'lib/color-variables';
+@use 'lib/color-variables';
 
-@import 'normalize';
+@use 'normalize';
 
-@import 'footer';
-@import 'form';
-@import 'header';
-@import 'instance';
-@import 'navigation';
-@import 'notification';
-@import 'page';
-@import 'text';
+@use 'footer';
+@use 'form';
+@use 'header';
+@use 'instance';
+@use 'navigation';
+@use 'notification';
+@use 'page';
+@use 'text';


### PR DESCRIPTION
The Sass docs ([Sass: @import](https://sass-lang.com/documentation/at-rules/import)) state:

> The Sass team discourages the continued use of the @import rule. Sass will [gradually phase it out](https://github.com/sass/sass/blob/master/accepted/module-system.md#timeline) over the next few years, and eventually remove it from the language entirely. Prefer the [@use rule](https://sass-lang.com/documentation/at-rules/use) instead. (Note that only Dart Sass currently supports @use. Users of other implementations must use the @import rule instead.)

This PR applies those recommended changes using the Sass Migrator tool, which was done using the following commands:

- Install the sass-migrator globally: `$ npm install -g sass-migrator`
- Run the Sass migration (this command is run from the root level of the directory): `$ sass-migrator module --migrate-deps ./src/client/stylesheets/index.scss`

### References:
- [Sass: @import](https://sass-lang.com/documentation/at-rules/import)
- [Sass: Migrator](https://sass-lang.com/documentation/cli/migrator)