### PR TITLE
Upgrade eslint-plugin-react 7.20.5 -> 7.31.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "css-loader": "^0.28.0",
     "eslint": "^7.5.0",
     "eslint-plugin-no-only-tests": "^2.4.0",
-    "eslint-plugin-react": "7.20.5",
+    "eslint-plugin-react": "7.31.8",
     "favicons-webpack-plugin": "^5.0.2",
     "lintspaces-cli": "^0.6.0",
     "mini-css-extract-plugin": "^2.2.2",

--- a/src/react/components/withInstancePageTitle.jsx
+++ b/src/react/components/withInstancePageTitle.jsx
@@ -3,40 +3,46 @@ import React from 'react';
 
 import { ACTIONS } from '../../utils/constants';
 
-const withInstancePageTitle = PageTitle => props => {
+const withInstancePageTitle = PageTitle => {
 
-	const { name, modelDisplayName, differentiatorSuffix, formAction } = props;
+	const _InstancePageTitle = props => {
 
-	const pageTitle = (action => {
+		const { name, modelDisplayName, differentiatorSuffix, formAction } = props;
 
-		switch (action) {
+		const pageTitle = (action => {
 
-			case ACTIONS.CREATE:
-				return `New ${modelDisplayName}`;
+			switch (action) {
 
-			case ACTIONS.UPDATE:
-				return `${name}${differentiatorSuffix}`;
+				case ACTIONS.CREATE:
+					return `New ${modelDisplayName}`;
 
-			default:
-				return '';
+				case ACTIONS.UPDATE:
+					return `${name}${differentiatorSuffix}`;
 
-		}
+				default:
+					return '';
 
-	})(formAction);
+			}
 
-	const isNewInstance = formAction === ACTIONS.CREATE;
+		})(formAction);
 
-	return (
-		<PageTitle text={pageTitle} isNewInstance={isNewInstance} />
-	);
+		const isNewInstance = formAction === ACTIONS.CREATE;
 
-};
+		return (
+			<PageTitle text={pageTitle} isNewInstance={isNewInstance} />
+		);
 
-withInstancePageTitle.propTypes = {
-	name: PropTypes.string.isRequired,
-	modelDisplayName: PropTypes.string.isRequired,
-	differentiatorSuffix: PropTypes.string,
-	formAction: PropTypes.string.isRequired
+	};
+
+	_InstancePageTitle.propTypes = {
+		name: PropTypes.string,
+		modelDisplayName: PropTypes.string,
+		differentiatorSuffix: PropTypes.string,
+		formAction: PropTypes.string
+	};
+
+	return _InstancePageTitle;
+
 };
 
 export default withInstancePageTitle;


### PR DESCRIPTION
This PR upgrades `eslint-plugin-react` to the current latest version.

Running it on the code's existing state produces the following errors:
```
/Users/andy.gout/Documents/theatrebase-cms/src/react/components/withInstancePageTitle.jsx
  6:44  error  Component definition is missing display name           react/display-name
  8:10  error  'name' is missing in props validation                  react/prop-types
  8:16  error  'modelDisplayName' is missing in props validation      react/prop-types
  8:34  error  'differentiatorSuffix' is missing in props validation  react/prop-types
  8:56  error  'formAction' is missing in props validation            react/prop-types
```

To satisfy these newly-enforced linting rules, this PR also revises the `withInstancePageTitle` Higher Order Component (HOC) so that the inner function is now named `_InstancePageTitle` (see below reference), which satisfies the `Component definition is missing display name ` error.

Doing this work made clear that `withInstancePageTitle.propTypes` was not actually enforcing types as expected, so this has also been changed to `_InstancePageTitle.propTypes`, which needs to sit within the Higher Order Component function.

### References:
- [Stack Overflow: PropTypes on Higher Order Components](https://stackoverflow.com/questions/37847616/proptypes-on-higher-order-components#answer-37885431)