### PR TITLE
Fix notifications

### DIFF
--- a/src/redux/actions/error.js
+++ b/src/redux/actions/error.js
@@ -12,7 +12,7 @@ const deactivateError = () => (dispatch, getState) => {
 
 	if (getIn(getState(), ['error', 'isActive'])) {
 
-		createAction(DEACTIVATE_ERROR, { isActive: false });
+		dispatch(createAction(DEACTIVATE_ERROR, { isActive: false }));
 
 	}
 

--- a/src/redux/actions/notification.js
+++ b/src/redux/actions/notification.js
@@ -12,7 +12,7 @@ const deactivateNotification = () => (dispatch, getState) => {
 
 	if (getIn(getState(), ['notification', 'isActive'])) {
 
-		createAction(DEACTIVATE_NOTIFICATION, { isActive: false });
+		dispatch(createAction(DEACTIVATE_NOTIFICATION, { isActive: false }));
 
 	}
 

--- a/src/redux/actions/redirect.js
+++ b/src/redux/actions/redirect.js
@@ -12,7 +12,7 @@ const deactivateRedirect = () => (dispatch, getState) => {
 
 	if (getIn(getState(), ['redirect', 'isActive'])) {
 
-		createAction(DEACTIVATE_REDIRECT, { isActive: false });
+		dispatch(createAction(DEACTIVATE_REDIRECT, { isActive: false }));
 
 	}
 


### PR DESCRIPTION
This [commit](https://github.com/andygout/theatrebase-cms/pull/188/commits/dd4d0e2d340be0ac32415cc869659e526791855e) in this PR https://github.com/andygout/theatrebase-cms/pull/188 unwittingly caused form error and success notifications to persist even after navigating to other pages via links.

This PR fixes this issue.