### PR TITLE
Replace getIn() with dot notation + optional chaining

### DIFF
--- a/src/react/components/instance-forms/AwardCeremonyForm.jsx
+++ b/src/react/components/instance-forms/AwardCeremonyForm.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
-import { getIn } from '../../../lib/object-interactions';
 import { capitalise } from '../../../lib/strings';
 import { ArrayItemActionButton, Fieldset, FieldsetComponent, FormWrapper, InputAndErrors } from '../form';
 import {
@@ -69,7 +68,7 @@ const AwardCeremonyForm = props => {
 
 									<InputAndErrors
 										value={member.name}
-										errors={getIn(member, ['errors', 'name'])}
+										errors={member.errors.name}
 										handleChange={event =>
 											handleChange(
 												categories,
@@ -86,7 +85,7 @@ const AwardCeremonyForm = props => {
 
 									<InputAndErrors
 										value={member.differentiator}
-										errors={getIn(member, ['errors', 'differentiator'])}
+										errors={member.errors.differentiator}
 										handleChange={event =>
 											handleChange(
 												categories,
@@ -138,7 +137,7 @@ const AwardCeremonyForm = props => {
 
 									<InputAndErrors
 										value={material.name}
-										errors={getIn(material, ['errors', 'name'])}
+										errors={material.errors.name}
 										handleChange={event =>
 											handleChange(
 												categories,
@@ -155,7 +154,7 @@ const AwardCeremonyForm = props => {
 
 									<InputAndErrors
 										value={material.differentiator}
-										errors={getIn(material, ['errors', 'differentiator'])}
+										errors={material.errors.differentiator}
 										handleChange={event =>
 											handleChange(
 												categories,
@@ -207,7 +206,7 @@ const AwardCeremonyForm = props => {
 
 									<InputAndErrors
 										value={production.uuid}
-										errors={getIn(production, ['errors', 'uuid'])}
+										errors={production.errors.uuid}
 										handleChange={event =>
 											handleChange(
 												categories,
@@ -259,7 +258,7 @@ const AwardCeremonyForm = props => {
 
 									<InputAndErrors
 										value={entity.name}
-										errors={getIn(entity, ['errors', 'name'])}
+										errors={entity.errors.name}
 										handleChange={event =>
 											handleChange(
 												categories,
@@ -276,7 +275,7 @@ const AwardCeremonyForm = props => {
 
 									<InputAndErrors
 										value={entity.differentiator}
-										errors={getIn(entity, ['errors', 'differentiator'])}
+										errors={entity.errors.differentiator}
 										handleChange={event =>
 											handleChange(
 												categories,
@@ -377,7 +376,7 @@ const AwardCeremonyForm = props => {
 
 									<InputAndErrors
 										value={nomination.customType}
-										errors={getIn(nomination, ['errors', 'customType'])}
+										errors={nomination.errors.customType}
 										handleChange={event =>
 											handleChange(
 												categories,
@@ -444,7 +443,7 @@ const AwardCeremonyForm = props => {
 
 									<InputAndErrors
 										value={category.name}
-										errors={getIn(category, ['errors', 'name'])}
+										errors={category.errors.name}
 										handleChange={event =>
 											handleChange(
 												categories,
@@ -492,7 +491,7 @@ const AwardCeremonyForm = props => {
 
 					<InputAndErrors
 						value={award?.name}
-						errors={award && getIn(award, ['errors', 'name'])}
+						errors={award?.errors.name}
 						handleChange={event => handleChange(award, setAward, ['name'], event)}
 					/>
 
@@ -502,7 +501,7 @@ const AwardCeremonyForm = props => {
 
 					<InputAndErrors
 						value={award?.differentiator}
-						errors={award && getIn(award, ['errors', 'differentiator'])}
+						errors={award?.errors.differentiator}
 						handleChange={event => handleChange(award, setAward, ['differentiator'], event)}
 					/>
 

--- a/src/react/components/instance-forms/MaterialForm.jsx
+++ b/src/react/components/instance-forms/MaterialForm.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
-import { getIn } from '../../../lib/object-interactions';
 import { capitalise } from '../../../lib/strings';
 import { ArrayItemActionButton, Fieldset, FieldsetComponent, FormWrapper, InputAndErrors } from '../form';
 import {
@@ -89,7 +88,7 @@ const MaterialForm = props => {
 
 									<InputAndErrors
 										value={entity.name}
-										errors={getIn(entity, ['errors', 'name'])}
+										errors={entity.errors.name}
 										handleChange={event =>
 											handleChange(
 												writingCredits,
@@ -106,7 +105,7 @@ const MaterialForm = props => {
 
 									<InputAndErrors
 										value={entity.differentiator}
-										errors={getIn(entity, ['errors', 'differentiator'])}
+										errors={entity.errors.differentiator}
 										handleChange={event =>
 											handleChange(
 												writingCredits,
@@ -216,7 +215,7 @@ const MaterialForm = props => {
 
 									<InputAndErrors
 										value={writingCredit.name}
-										errors={getIn(writingCredit, ['errors', 'name'])}
+										errors={writingCredit.errors.name}
 										handleChange={event =>
 											handleChange(
 												writingCredits,
@@ -328,7 +327,7 @@ const MaterialForm = props => {
 
 									<InputAndErrors
 										value={subMaterial.name}
-										errors={getIn(subMaterial, ['errors', 'name'])}
+										errors={subMaterial.errors.name}
 										handleChange={event =>
 											handleChange(
 												subMaterials,
@@ -345,7 +344,7 @@ const MaterialForm = props => {
 
 									<InputAndErrors
 										value={subMaterial.differentiator}
-										errors={getIn(subMaterial, ['errors', 'differentiator'])}
+										errors={subMaterial.errors.differentiator}
 										handleChange={event =>
 											handleChange(
 												subMaterials,
@@ -407,7 +406,7 @@ const MaterialForm = props => {
 
 									<InputAndErrors
 										value={character.name}
-										errors={getIn(character, ['errors', 'name'])}
+										errors={character.errors.name}
 										handleChange={event =>
 											handleChange(
 												characterGroups,
@@ -424,7 +423,7 @@ const MaterialForm = props => {
 
 									<InputAndErrors
 										value={character.underlyingName}
-										errors={getIn(character, ['errors', 'underlyingName'])}
+										errors={character.errors.underlyingName}
 										handleChange={event =>
 											handleChange(
 												characterGroups,
@@ -441,7 +440,7 @@ const MaterialForm = props => {
 
 									<InputAndErrors
 										value={character.differentiator}
-										errors={getIn(character, ['errors', 'differentiator'])}
+										errors={character.errors.differentiator}
 										handleChange={event =>
 											handleChange(
 												characterGroups,
@@ -458,7 +457,7 @@ const MaterialForm = props => {
 
 									<InputAndErrors
 										value={character.qualifier}
-										errors={getIn(character, ['errors', 'qualifier'])}
+										errors={character.errors.qualifier}
 										handleChange={event =>
 											handleChange(
 												characterGroups,
@@ -520,7 +519,7 @@ const MaterialForm = props => {
 
 									<InputAndErrors
 										value={characterGroup.name}
-										errors={getIn(characterGroup, ['errors', 'name'])}
+										errors={characterGroup.errors.name}
 										handleChange={event =>
 											handleChange(
 												characterGroups,
@@ -599,7 +598,7 @@ const MaterialForm = props => {
 
 					<InputAndErrors
 						value={originalVersionMaterial?.name}
-						errors={originalVersionMaterial && getIn(originalVersionMaterial, ['errors', 'name'])}
+						errors={originalVersionMaterial?.errors.name}
 						handleChange={event =>
 							handleChange(
 								originalVersionMaterial,
@@ -616,7 +615,7 @@ const MaterialForm = props => {
 
 					<InputAndErrors
 						value={originalVersionMaterial?.differentiator}
-						errors={originalVersionMaterial && getIn(originalVersionMaterial, ['errors', 'differentiator'])}
+						errors={originalVersionMaterial?.errors.differentiator}
 						handleChange={event =>
 							handleChange(
 								originalVersionMaterial,

--- a/src/react/components/instance-forms/ProductionForm.jsx
+++ b/src/react/components/instance-forms/ProductionForm.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
-import { getIn } from '../../../lib/object-interactions';
 import { capitalise } from '../../../lib/strings';
 import { ArrayItemActionButton, Fieldset, FieldsetComponent, FormWrapper, InputAndErrors } from '../form';
 import {
@@ -100,7 +99,7 @@ const ProductionForm = props => {
 
 									<InputAndErrors
 										value={subProduction.uuid}
-										errors={getIn(subProduction, ['errors', 'uuid'])}
+										errors={subProduction.errors.uuid}
 										handleChange={event =>
 											handleChange(
 												subProductions,
@@ -152,7 +151,7 @@ const ProductionForm = props => {
 
 									<InputAndErrors
 										value={member.name}
-										errors={getIn(member, ['errors', 'name'])}
+										errors={member.errors.name}
 										handleChange={event =>
 											handleChange(
 												stateValue,
@@ -169,7 +168,7 @@ const ProductionForm = props => {
 
 									<InputAndErrors
 										value={member.differentiator}
-										errors={getIn(member, ['errors', 'differentiator'])}
+										errors={member.errors.differentiator}
 										handleChange={event =>
 											handleChange(
 												stateValue,
@@ -221,7 +220,7 @@ const ProductionForm = props => {
 
 									<InputAndErrors
 										value={entity.name}
-										errors={getIn(entity, ['errors', 'name'])}
+										errors={entity.errors.name}
 										handleChange={event =>
 											handleChange(
 												stateValue,
@@ -238,7 +237,7 @@ const ProductionForm = props => {
 
 									<InputAndErrors
 										value={entity.differentiator}
-										errors={getIn(entity, ['errors', 'differentiator'])}
+										errors={entity.errors.differentiator}
 										handleChange={event =>
 											handleChange(
 												stateValue,
@@ -346,7 +345,7 @@ const ProductionForm = props => {
 
 									<InputAndErrors
 										value={producerCredit.name}
-										errors={getIn(producerCredit, ['errors', 'name'])}
+										errors={producerCredit.errors.name}
 										handleChange={event =>
 											handleChange(
 												producerCredits,
@@ -408,7 +407,7 @@ const ProductionForm = props => {
 
 									<InputAndErrors
 										value={role.name}
-										errors={getIn(role, ['errors', 'name'])}
+										errors={role.errors.name}
 										handleChange={event =>
 											handleChange(
 												cast,
@@ -425,7 +424,7 @@ const ProductionForm = props => {
 
 									<InputAndErrors
 										value={role.characterName}
-										errors={getIn(role, ['errors', 'characterName'])}
+										errors={role.errors.characterName}
 										handleChange={event =>
 											handleChange(
 												cast,
@@ -442,7 +441,7 @@ const ProductionForm = props => {
 
 									<InputAndErrors
 										value={role.characterDifferentiator}
-										errors={getIn(role, ['errors', 'characterDifferentiator'])}
+										errors={role.errors.characterDifferentiator}
 										handleChange={event =>
 											handleChange(
 												cast,
@@ -459,7 +458,7 @@ const ProductionForm = props => {
 
 									<InputAndErrors
 										value={role.qualifier}
-										errors={getIn(role, ['errors', 'qualifier'])}
+										errors={role.errors.qualifier}
 										handleChange={event =>
 											handleChange(
 												cast,
@@ -528,7 +527,7 @@ const ProductionForm = props => {
 
 									<InputAndErrors
 										value={castMember.name}
-										errors={getIn(castMember, ['errors', 'name'])}
+										errors={castMember.errors.name}
 										handleChange={event =>
 											handleChange(
 												cast,
@@ -545,7 +544,7 @@ const ProductionForm = props => {
 
 									<InputAndErrors
 										value={castMember.differentiator}
-										errors={getIn(castMember, ['errors', 'differentiator'])}
+										errors={castMember.errors.differentiator}
 										handleChange={event =>
 											handleChange(
 												cast,
@@ -609,7 +608,7 @@ const ProductionForm = props => {
 
 									<InputAndErrors
 										value={creativeCredit.name}
-										errors={getIn(creativeCredit, ['errors', 'name'])}
+										errors={creativeCredit.errors.name}
 										handleChange={event =>
 											handleChange(
 												creativeCredits,
@@ -671,7 +670,7 @@ const ProductionForm = props => {
 
 									<InputAndErrors
 										value={crewCredit.name}
-										errors={getIn(crewCredit, ['errors', 'name'])}
+										errors={crewCredit.errors.name}
 										handleChange={event =>
 											handleChange(
 												crewCredits,
@@ -764,7 +763,7 @@ const ProductionForm = props => {
 
 					<InputAndErrors
 						value={material?.name}
-						errors={material && getIn(material, ['errors', 'name'])}
+						errors={material?.errors.name}
 						handleChange={event => handleChange(material, setMaterial, ['name'], event)}
 					/>
 
@@ -774,7 +773,7 @@ const ProductionForm = props => {
 
 					<InputAndErrors
 						value={material?.differentiator}
-						errors={material && getIn(material, ['errors', 'differentiator'])}
+						errors={material?.errors.differentiator}
 						handleChange={event => handleChange(material, setMaterial, ['differentiator'], event)}
 					/>
 
@@ -788,7 +787,7 @@ const ProductionForm = props => {
 
 					<InputAndErrors
 						value={venue?.name}
-						errors={venue && getIn(venue, ['errors', 'name'])}
+						errors={venue?.errors.name}
 						handleChange={event => handleChange(venue, setVenue, ['name'], event)}
 					/>
 
@@ -798,7 +797,7 @@ const ProductionForm = props => {
 
 					<InputAndErrors
 						value={venue?.differentiator}
-						errors={venue && getIn(venue, ['errors', 'differentiator'])}
+						errors={venue?.errors.differentiator}
 						handleChange={event => handleChange(venue, setVenue, ['differentiator'], event)}
 					/>
 

--- a/src/react/components/instance-forms/VenueForm.jsx
+++ b/src/react/components/instance-forms/VenueForm.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
-import { getIn } from '../../../lib/object-interactions';
 import { ArrayItemActionButton, Fieldset, FieldsetComponent, FormWrapper, InputAndErrors } from '../form';
 import {
 	handleChange,
@@ -62,7 +61,7 @@ const VenueForm = props => {
 
 									<InputAndErrors
 										value={subVenue.name}
-										errors={getIn(subVenue, ['errors', 'name'])}
+										errors={subVenue.errors.name}
 										handleChange={event =>
 											handleChange(
 												subVenues,
@@ -79,7 +78,7 @@ const VenueForm = props => {
 
 									<InputAndErrors
 										value={subVenue.differentiator}
-										errors={getIn(subVenue, ['errors', 'differentiator'])}
+										errors={subVenue.errors.differentiator}
 										handleChange={event =>
 											handleChange(
 												subVenues,

--- a/src/redux/actions/error.js
+++ b/src/redux/actions/error.js
@@ -1,4 +1,3 @@
-import { getIn } from '../../lib/object-interactions';
 import createAction from './base';
 import {
 	ACTIVATE_ERROR,
@@ -10,7 +9,7 @@ const activateError = errorData =>
 
 const deactivateError = () => (dispatch, getState) => {
 
-	if (getIn(getState(), ['error', 'isActive'])) {
+	if (getState().error.isActive) {
 
 		dispatch(createAction(DEACTIVATE_ERROR, { isActive: false }));
 

--- a/src/redux/actions/model.js
+++ b/src/redux/actions/model.js
@@ -175,7 +175,7 @@ const fetchInstance = (model, uuid = null) => async dispatch => {
 	// add `getState` to this function's args:
 	// `const fetchInstance = (model, uuid = null) => async (dispatch, getState) => {`
 	// and wrap the remaining code of this function in a conditional based on `apiCallRequired`:
-	// `const apiCallRequired = isInstance ? getIn(getState(), [model, 'uuid']) !== uuid : !getState()[model].length;`
+	// `const apiCallRequired = isInstance ? getState()[model].uuid !== uuid : !getState()[model].length;`
 	// This is not applied here because it is necessary for a CMS to display the most current data from source.
 
 	dispatch(requestInstance(model));

--- a/src/redux/actions/notification.js
+++ b/src/redux/actions/notification.js
@@ -1,4 +1,3 @@
-import { getIn } from '../../lib/object-interactions';
 import createAction from './base';
 import {
 	ACTIVATE_NOTIFICATION,
@@ -10,7 +9,7 @@ const activateNotification = notificationData =>
 
 const deactivateNotification = () => (dispatch, getState) => {
 
-	if (getIn(getState(), ['notification', 'isActive'])) {
+	if (getState().notification.isActive) {
 
 		dispatch(createAction(DEACTIVATE_NOTIFICATION, { isActive: false }));
 

--- a/src/redux/actions/redirect.js
+++ b/src/redux/actions/redirect.js
@@ -1,4 +1,3 @@
-import { getIn } from '../../lib/object-interactions';
 import createAction from './base';
 import {
 	ACTIVATE_REDIRECT,
@@ -10,7 +9,7 @@ const activateRedirect = redirectData =>
 
 const deactivateRedirect = () => (dispatch, getState) => {
 
-	if (getIn(getState(), ['redirect', 'isActive'])) {
+	if (getState().redirect.isActive) {
 
 		dispatch(createAction(DEACTIVATE_REDIRECT, { isActive: false }));
 


### PR DESCRIPTION
This previous PR https://github.com/andygout/theatrebase-cms/pull/187 switched from Immutable.js to plain JavaScript objects and added a custom `getIn()` function that performed the equivalent purpose as that provided by Immutable.js.

However, JavaScript properties can be accessed simply by dot notation and so this PR replaces those instances.

An instance still remains in `/src/react/utils/form.js` (below) because the `statePathToInnermostArray` value is an array of values (e.g. `[1, "nominations", 3, "entities"]`) which cannot be used by dot notation to acquire the innermost value.

```js
const innermostArray = getIn(stateValue, statePathToInnermostArray);
```