### PR TITLE
Change title text colours

### DIFF
--- a/src/client/stylesheets/_form.scss
+++ b/src/client/stylesheets/_form.scss
@@ -51,7 +51,7 @@ $action-button-height: 18px;
 	height: $action-button-height;
 	width: 36px;
 	line-height: $action-button-height;
-	color: color-variables.$theme-color;
+	color: color-variables.$interactive-text-color;
 	background-color: color-variables.$content-background-color;
 	border: 1px solid color-variables.$border-color;
 	border-radius: 5px;

--- a/src/client/stylesheets/_page.scss
+++ b/src/client/stylesheets/_page.scss
@@ -21,7 +21,7 @@ body {
 }
 
 a {
-	color: color-variables.$theme-color;
+	color: color-variables.$interactive-text-color;
 
 	&:hover {
 		color: color-variables.$default-text-color;

--- a/src/client/stylesheets/_text.scss
+++ b/src/client/stylesheets/_text.scss
@@ -4,9 +4,9 @@
 	margin: 0 5px 20px 5px;
 	padding-bottom: 0px;
 	font-size: xx-large;
-	color: color-variables.$theme-color;
+	color: color-variables.$default-text-color;
 }
 
 .title-text--muted {
-	color: color-variables.$default-text-color;
+	color: color-variables.$muted-text-color;
 }

--- a/src/client/stylesheets/lib/_color-variables.scss
+++ b/src/client/stylesheets/lib/_color-variables.scss
@@ -10,5 +10,6 @@ $header-background-color: #000000;
 $header-text-color: #1975A3;
 $header-text-color-hover: #3083AC;
 $html-background-color: #F0F0F0;
+$interactive-text-color: #006699;
+$muted-text-color: #949494;
 $success-color: #D8EDDD;
-$theme-color: #006699;


### PR DESCRIPTION
This PR changes the title text colours:

- **title text:** theme colour -> default text colour
- **muted title text:** default text colour -> muted text colour

The decision has been made because the theme colour is used to denote that text is a link so is inconsistent and misleading to be used for the title text (which is not a link).

The muted title text (used for the title of a new instance form) has to be differentiated from the colour used for the main title text, and so a lightly shade of grey (the same as is used for borders of certain elements, e.g. labels, notifications, fieldsets).

---

### New form

#### Before:
<img width="999" alt="cms-new-before" src="https://user-images.githubusercontent.com/10484515/212738779-4cd6ca50-7cb4-447c-bf0f-4d2b94f341c0.png">

#### After:
<img width="999" alt="cms-new-after" src="https://user-images.githubusercontent.com/10484515/212738979-f17f881e-5029-4b00-8746-f48b55822a26.png">

---

### Edit form

#### Before:
<img width="998" alt="cms-edit-before" src="https://user-images.githubusercontent.com/10484515/212738805-18284e1e-cb6f-4d50-bd68-2c3d3fa24bbc.png">

#### After:
<img width="998" alt="cms-edit-after" src="https://user-images.githubusercontent.com/10484515/212738840-45f55dd7-4227-448b-8f9a-2440c49401f6.png">