### PR TITLE
Upgrade npm from v9.8.1 to v10.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   ],
   "engines": {
     "node": "20.5.0",
-    "npm": "9.8.1"
+    "npm": "10.2.1"
   },
   "volta": {
     "node": "20.5.0",
-    "npm": "9.8.1"
+    "npm": "10.2.1"
   },
   "dependencies": {
     "classnames": "2.3.2",


### PR DESCRIPTION
This PR upgrades npm (Node Package Manager) to the current latest version: [v10.2.1](https://github.com/npm/cli/releases/tag/v10.2.1)