### PR TITLE
Apply Node v18 features

### DIFF
--- a/src/lib/prune-instance.js
+++ b/src/lib/prune-instance.js
@@ -24,10 +24,10 @@ const pruneInstance = (instance, recursions = 0) => {
 			accumulator[key] =
 				instance[key]
 					.filter((item, index) =>
-						index === 0 || !Object.prototype.hasOwnProperty.call(item, 'name') || Boolean(item.name)
+						index === 0 || !Object.hasOwn(item, 'name') || Boolean(item.name)
 					)
 					.filter((item, index) =>
-						index === 0 || !Object.prototype.hasOwnProperty.call(item, 'uuid') || Boolean(item.uuid)
+						index === 0 || !Object.hasOwn(item, 'uuid') || Boolean(item.uuid)
 					)
 					.map(item => isObjectWithKeys(item) ? pruneInstance(item, recursions + 1) : item);
 


### PR DESCRIPTION
This PR applies some of the features we gain from running on a Node.js version of 18 or above, as described in this blog:

[The features we gain from the Node.js 16 sunset](https://financialtimes.atlassian.net/wiki/spaces/DS/blog/2023/09/06/8135344184/The+features+we+gain+from+the+Node.js+16+sunset) by @rowanmanning

### References:
- [MDN Web Docs: JavaScript — Object.hasOwn()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn)