### PR TITLE
Add material/production subtitle fieldset

### DIFF
--- a/src/react/components/instance-forms/MaterialForm.jsx
+++ b/src/react/components/instance-forms/MaterialForm.jsx
@@ -17,6 +17,7 @@ const MaterialForm = props => {
 
 	const [name, setName] = useState(instance.name);
 	const [differentiator, setDifferentiator] = useState(instance.differentiator);
+	const [subtitle, setSubtitle] = useState(instance.subtitle);
 	const [format, setFormat] = useState(instance.format);
 	const [year, setYear] = useState(instance.year);
 	const [originalVersionMaterial, setOriginalVersionMaterial] = useState(instance.originalVersionMaterial);
@@ -28,6 +29,7 @@ const MaterialForm = props => {
 	useEffect(() => {
 		setName(instance.name);
 		setDifferentiator(instance.differentiator);
+		setSubtitle(instance.subtitle);
 		setFormat(instance.format);
 		setYear(instance.year);
 		setOriginalVersionMaterial(instance.originalVersionMaterial);
@@ -42,6 +44,7 @@ const MaterialForm = props => {
 		uuid: instance.uuid,
 		name,
 		differentiator,
+		subtitle,
 		format,
 		year,
 		originalVersionMaterial,
@@ -567,6 +570,16 @@ const MaterialForm = props => {
 					value={differentiator}
 					errors={errors?.differentiator}
 					handleChange={event => handleChange(differentiator, setDifferentiator, [], event)}
+				/>
+
+			</Fieldset>
+
+			<Fieldset header={'Subtitle'}>
+
+				<InputAndErrors
+					value={subtitle}
+					errors={errors?.subtitle}
+					handleChange={event => handleChange(subtitle, setSubtitle, [], event)}
 				/>
 
 			</Fieldset>

--- a/src/react/components/instance-forms/ProductionForm.jsx
+++ b/src/react/components/instance-forms/ProductionForm.jsx
@@ -18,6 +18,7 @@ const ProductionForm = props => {
 	const { instance, action } = props;
 
 	const [name, setName] = useState(instance.name);
+	const [subtitle, setSubtitle] = useState(instance.subtitle);
 	const [startDate, setStartDate] = useState(instance.startDate);
 	const [pressDate, setPressDate] = useState(instance.pressDate);
 	const [endDate, setEndDate] = useState(instance.endDate);
@@ -34,6 +35,7 @@ const ProductionForm = props => {
 
 	useEffect(() => {
 		setName(instance.name);
+		setSubtitle(instance.subtitle);
 		setStartDate(instance.startDate);
 		setPressDate(instance.pressDate);
 		setEndDate(instance.endDate);
@@ -53,6 +55,7 @@ const ProductionForm = props => {
 		model: instance.model,
 		uuid: instance.uuid,
 		name,
+		subtitle,
 		startDate,
 		pressDate,
 		endDate,
@@ -722,6 +725,16 @@ const ProductionForm = props => {
 					value={name}
 					errors={errors?.name}
 					handleChange={event => handleChange(name, setName, [], event)}
+				/>
+
+			</Fieldset>
+
+			<Fieldset header={'Subtitle'}>
+
+				<InputAndErrors
+					value={subtitle}
+					errors={errors?.subtitle}
+					handleChange={event => handleChange(subtitle, setSubtitle, [], event)}
 				/>
 
 			</Fieldset>


### PR DESCRIPTION
This PR adds functionality to be able to add/edit material/production subtitle as implemented in this API PR: https://github.com/andygout/theatrebase-api/pull/644.

---

#### Edit material form
<img width="936" alt="material-edit" src="https://github.com/andygout/theatrebase-cms/assets/10484515/44b36790-4057-4a55-ba5e-06018298f83a">

---

#### Edit production form
<img width="940" alt="production-edit" src="https://github.com/andygout/theatrebase-cms/assets/10484515/0008b35d-3e60-4a7d-95ff-87f19906f502">
