### PR TITLE
Add search bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "npm": "10.2.1"
   },
   "dependencies": {
+    "bootstrap": "^5.3.3",
     "classnames": "2.3.2",
     "express": "4.18.1",
     "express-handlebars": "6.0.6",
@@ -34,6 +35,7 @@
     "morgan": "1.10.0",
     "prop-types": "15.8.1",
     "react": "18.2.0",
+    "react-bootstrap-typeahead": "^6.3.2",
     "react-dom": "18.2.0",
     "react-helmet": "6.1.0",
     "react-redux": "8.0.4",

--- a/src/client/stylesheets/_dropdown-modifiers.scss
+++ b/src/client/stylesheets/_dropdown-modifiers.scss
@@ -1,0 +1,32 @@
+@use 'lib/color-variables';
+
+.dropdown-menu {
+	padding: 8px !important;
+	box-sizing: border-box;
+}
+
+.dropdown-item {
+	padding: 8px 4px !important;
+	box-sizing: border-box;
+	line-height: 20px;
+	color: color-variables.$default-text-color !important;
+	cursor: pointer !important;
+}
+
+.dropdown-item:not(:last-child) {
+	border-bottom: 1px solid color-variables.$autocomplete-option-border-color !important;
+}
+
+.dropdown-item.active, .dropdown-item:active {
+	color: color-variables.$autocomplete-selected-option-color !important;
+	background-color: color-variables.$autocomplete-selected-option-background-color !important;
+	border-color: color-variables.$autocomplete-selected-option-background-color !important;
+
+	.dropdown-item-suffix {
+		color: color-variables.$autocomplete-selected-option-color;
+	}
+}
+
+.dropdown-item-suffix {
+	color: color-variables.$autocomplete-option-suffix-color;
+}

--- a/src/client/stylesheets/_form-control-modifiers.scss
+++ b/src/client/stylesheets/_form-control-modifiers.scss
@@ -1,0 +1,9 @@
+@use 'lib/color-variables';
+
+.form-control {
+	color: color-variables.$default-text-color !important;
+}
+
+.form-control:focus {
+	border-color: color-variables.$autocomplete-selected-option-background-color !important;
+}

--- a/src/client/stylesheets/_header.scss
+++ b/src/client/stylesheets/_header.scss
@@ -1,8 +1,15 @@
 @use 'lib/color-variables';
 
 .header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 	background-color: color-variables.$header-background-color;
 	padding: 0 10px;
+}
+
+.header__component {
+	flex: 1;
 }
 
 .header__home-link {

--- a/src/client/stylesheets/_page.scss
+++ b/src/client/stylesheets/_page.scss
@@ -4,13 +4,13 @@
 	margin: 0;
 	padding: 0;
 	font-family: arial, sans-serif;
-	color: color-variables.$default-text-color;
 	text-decoration: none;
 }
 
 html {
 	height: 100%;
 	text-align: center;
+	color: color-variables.$default-text-color;
 	background-color: color-variables.$html-background-color;
 }
 
@@ -26,6 +26,10 @@ a {
 	&:hover {
 		color: color-variables.$default-text-color;
 	}
+}
+
+button {
+	cursor: pointer;
 }
 
 .page-container {

--- a/src/client/stylesheets/index.scss
+++ b/src/client/stylesheets/index.scss
@@ -10,3 +10,29 @@
 @use 'notification';
 @use 'page';
 @use 'text';
+
+@use 'dropdown-modifiers';
+@use 'form-control-modifiers';
+
+@import 'react-bootstrap-typeahead/css/Typeahead.css';
+@import 'react-bootstrap-typeahead/css/Typeahead.bs5.css';
+
+// Functions first
+@import 'bootstrap/scss/functions';
+
+// Variable overrides second
+$primary: #900;
+$enable-shadows: true;
+$prefix: 'bs-';
+
+// Required Bootstrap imports
+@import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/maps';
+@import 'bootstrap/scss/mixins';
+@import 'bootstrap/scss/root';
+@import 'bootstrap/scss/helpers/visually-hidden';
+
+// Optional components
+@import 'bootstrap/scss/forms/form-control';
+@import 'bootstrap/scss/dropdown';
+@import 'bootstrap/scss/spinners';

--- a/src/client/stylesheets/lib/_color-variables.scss
+++ b/src/client/stylesheets/lib/_color-variables.scss
@@ -1,3 +1,7 @@
+$autocomplete-option-border-color: #E3E3E3;
+$autocomplete-option-suffix-color: #949494;
+$autocomplete-selected-option-background-color: #006699;
+$autocomplete-selected-option-color: #FFFFFF;
 $border-color: #949494;
 $box-shadow-color: #D0D0D0;
 $button-background-color: #E8E8E8;

--- a/src/lib/fetch-from-api.js
+++ b/src/lib/fetch-from-api.js
@@ -1,0 +1,43 @@
+const API_URL_BASE = 'http://localhost:3000';
+
+export default async apiPath => {
+
+	const apiUrl = `${API_URL_BASE}${apiPath}`;
+
+	try {
+
+		const response = await fetch(apiUrl);
+
+		if (response.status !== 200) {
+
+			const { status, statusText } = response;
+
+			const error = new Error(statusText);
+
+			error.status = status;
+
+			throw error;
+
+		}
+
+		const data = await response.json();
+
+		return data;
+
+	} catch (error) {
+
+		// If fetch is successful but provides a non-200 response.
+		if (typeof error.status === 'number') throw error;
+
+		// If fetch is unsuccessful its error will not have a `status` attribute
+		// but instead have a `code` attribute whose value is 'ECONNREFUSED',
+		// making a 500 response code the most instructive for this scenario.
+		const internalServerError = new Error('Internal Server Error', { cause: error });
+
+		internalServerError.status = 500;
+
+		throw internalServerError;
+
+	}
+
+};

--- a/src/react/components/Header.jsx
+++ b/src/react/components/Header.jsx
@@ -1,14 +1,20 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
+import { SearchBar } from '.';
+
 const Header = () => {
 
 	return (
 		<header className="header">
 
-			<Link to={'/'} className="header__home-link">
+			<Link to={'/'} className="header__component header__home-link">
 				TheatreBase
 			</Link>
+
+			<div className="header__component">
+				<SearchBar />
+			</div>
 
 		</header>
 	);

--- a/src/react/components/SearchBar.jsx
+++ b/src/react/components/SearchBar.jsx
@@ -1,0 +1,87 @@
+/* eslint no-unused-vars: ["error", { "argsIgnorePattern": "(newSelectionPrefix|paginationText|renderMenuItemChildren)" }] */
+
+import React, { useState } from 'react';
+import { AsyncTypeahead, Highlighter } from 'react-bootstrap-typeahead';
+import { useNavigate } from 'react-router-dom';
+
+import { MODEL_TO_DISPLAY_NAME_MAP, MODEL_TO_ROUTE_MAP } from '../../utils/constants';
+
+const URL_BASE = 'http://localhost:3001';
+
+async function performFetch (url) {
+
+	const response = await fetch(url, { mode: 'cors' });
+
+	if (response.status !== 200) throw new Error(response.statusText);
+
+	const searchResults = await response.json();
+
+	return searchResults;
+
+}
+
+const SearchBar = () => {
+
+	const [isLoading, setIsLoading] = useState(false);
+	const [options, setOptions] = useState([]);
+
+	const navigate = useNavigate();
+
+	const handleSearch = async searchTerm => {
+
+		setIsLoading(true);
+
+		const url = `${URL_BASE}/api/search?searchTerm=${searchTerm}`;
+
+		const searchResults = await performFetch(url);
+
+		setOptions(searchResults);
+
+		setIsLoading(false);
+
+	};
+
+	const handleChange = ([selectedOption]) => {
+
+		if (selectedOption) {
+
+			const { model, uuid } = selectedOption;
+
+			const instancePath = `/${MODEL_TO_ROUTE_MAP[model]}/${uuid}`;
+
+			navigate(instancePath);
+
+		}
+
+	};
+
+	return (
+		<AsyncTypeahead
+			id='search-result-options'
+			filterBy={() => true}
+			delay={1000}
+			isLoading={isLoading}
+			labelKey='name'
+			minLength={3}
+			maxHeight={'200px'}
+			onSearch={handleSearch}
+			onChange={handleChange}
+			options={options}
+			placeholder='Search TheatreBase…'
+			emptyLabel='No results found'
+			renderMenuItemChildren={(option, { text }) => (
+				<>
+					<Highlighter search={text}>
+						{option.name}
+					</Highlighter>
+					{' '}
+					<span className="dropdown-item-suffix">
+						({MODEL_TO_DISPLAY_NAME_MAP[option.model]})
+					</span>
+				</>
+			)}
+		/>
+	);
+};
+
+export default SearchBar;

--- a/src/react/components/index.js
+++ b/src/react/components/index.js
@@ -8,6 +8,7 @@ import Navigation from './Navigation';
 import Notification from './Notification';
 import PageTitle from './PageTitle';
 import ScrollToTop from './ScrollToTop';
+import SearchBar from './SearchBar';
 import withInstancePageTitle from './withInstancePageTitle';
 
 export {
@@ -21,5 +22,6 @@ export {
 	Notification,
 	PageTitle,
 	ScrollToTop,
+	SearchBar,
 	withInstancePageTitle
 };

--- a/src/server/api-router.js
+++ b/src/server/api-router.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+import { search as searchController } from './controllers';
+
+const router = new Router();
+
+router.get('/search', (request, response, next) =>
+	searchController(request, response, next));
+
+export default router;

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -8,6 +8,7 @@ import logger from 'morgan';
 import favicon from 'serve-favicon';
 
 import { errorHandler } from './middleware';
+import apiRouter from './api-router';
 import router from './router';
 
 const app = express();
@@ -20,10 +21,14 @@ app.use(
 	favicon(path.join(__dirname, 'assets', 'favicon.ico')), // Path is relative to `built/main.js`.
 	logger('dev'),
 	session({ secret: 'secret', resave: false, saveUninitialized: true }),
-	express.static('public'),
-	router,
-	errorHandler
+	express.static('public')
 );
+
+app.use('/api', apiRouter);
+
+app.use(router);
+
+app.use(errorHandler);
 
 const port = '3001';
 

--- a/src/server/controllers/index.js
+++ b/src/server/controllers/index.js
@@ -1,0 +1,5 @@
+import search from './search';
+
+export {
+	search
+};

--- a/src/server/controllers/search.js
+++ b/src/server/controllers/search.js
@@ -1,0 +1,19 @@
+import fetchFromApi from '../../lib/fetch-from-api';
+
+export default async (request, response, next) => {
+
+	const { query: { searchTerm } } = request;
+
+	try {
+
+		const searchResults = await fetchFromApi(`/search?searchTerm=${searchTerm}`);
+
+		return response.send(searchResults);
+
+	} catch (error) {
+
+		return next(error);
+
+	}
+
+};


### PR DESCRIPTION
This PR adds a search bar component that consumes from the search endpoint added by this API PR https://github.com/andygout/theatrebase-api/pull/649.

It uses an identical approach to https://github.com/andygout/theatrebase-spa/pull/208.

It uses the React Bootstrap Typeahead component and applies styling overrides to make it stylistically consistent with the search bar implement in theatrebase-ssr.

<img width="1004" alt="cms" src="https://github.com/andygout/theatrebase-cms/assets/10484515/bfe1fd1a-338a-4c3e-8a83-26767ed55088">

### Notes:

#### 1.
It does not add a clear (i.e. 'X') button, which is possible (see: https://ericgio.github.io/react-bootstrap-typeahead/#controlling-selections; it only requires the presence of a `clearButton` property passed to the `AsynTypeahead` component), but the chosen implementation makes it redundant: clicking or pressing return on any suggestion will redirect to that page; there is no chance for it to populate the input for it to then be cleared. The `AsyncTypeahead`'s clear button only works in relation to input that derived from the suggestions; it does not apply to characters purely entered into the input by the user.

#### 2.
An alternate approach was initially attempted using the `AsyncTypeahead`'s `renderMenu` property (see below), which allows for more granular control over the `Menu` as well as the `MenuItem` children (as has ultimate been achieved by the `AsyncTypeahead`'s `renderMenuItemChildren` property), though the control required was ultimately enabled via the `onChange` property.

```jsx
renderMenu={(
	results,
	{ newSelectionPrefix, paginationText, renderMenuItemChildren, ...menuProps },
	state
) =>
	<Menu {...menuProps}>
		{results.map((result, index) =>
			<MenuItem
				key={result.uuid}
				option={result}
				position={index}
				onClick={() => navigate(`/${MODEL_TO_ROUTE_MAP[result.model]}/${result.uuid}`)}
			>
				<Highlighter search={state.text}>
					{result.name}
				</Highlighter>
				{' '}
				<span>
					({MODEL_TO_DISPLAY_NAME_MAP[result.model]})
				</span>
			</MenuItem>
		)}
	</Menu>
}
```

N.B. The destructuring of `newSelectionPrefix`, `paginationText`, and `renderMenuItemChildren` is necessary to avoid client-side console warnings to the effect of:

> React does not recognize the `newSelectionPrefix` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `newselectionprefix` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

### References:
- [React Bootstrap Typeahead Example](https://ericgio.github.io/react-bootstrap-typeahead)
- [Stack Overflow: reactjs — React Bootstrap Typeahead children onclick](https://stackoverflow.com/questions/59168666/react-bootstrap-typeahead-children-onclick)
- [Stack Overflow: javascript — How to do a redirect to another route with react-router?](https://stackoverflow.com/questions/34735580/how-to-do-a-redirect-to-another-route-with-react-router)
  - Explanation of use of `navigate` in this PR

### New dependencies:
- [npm: bootstrap](https://www.npmjs.com/package/bootstrap)
- [npm: react-bootstrap-typeahead](https://www.npmjs.com/package/react-bootstrap-typeahead)