### PR TITLE
Change project name: TheatreBase -> Dramatis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# theatrebase-cms [![CircleCI](https://circleci.com/gh/andygout/theatrebase-cms/tree/main.svg?style=svg)](https://circleci.com/gh/andygout/theatrebase-cms/tree/main)
+# dramatis-cms [![CircleCI](https://circleci.com/gh/andygout/dramatis-cms/tree/main.svg?style=svg)](https://circleci.com/gh/andygout/dramatis-cms/tree/main)
 
 Content Management System (CMS) for managing database of theatrical productions, materials, and associated data.
 
@@ -9,7 +9,7 @@ Content Management System (CMS) for managing database of theatrical productions,
 - Compile code: `$ npm run build`
 
 ## To run locally
-- Ensure an instance of [`theatrebase-api`](https://github.com/andygout/theatrebase-api) is running on `http://localhost:3000`
+- Ensure an instance of [`dramatis-api`](https://github.com/andygout/dramatis-api) is running on `http://localhost:3000`
 - Run server using `$ npm start` and visit homepage at `http://localhost:3001`
 
 ## To run linting checks

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "theatrebase-cms",
+  "name": "dramatis-cms",
   "version": "0.0.0",
   "description": "Content Management System (CMS) for managing database of theatrical productions, materials, and associated data.",
   "author": "https://github.com/andygout",

--- a/src/react/Layout.jsx
+++ b/src/react/Layout.jsx
@@ -53,8 +53,8 @@ const Layout = props => {
 		<>
 
 			<Helmet
-				defaultTitle='TheatreBase'
-				titleTemplate='%s | TheatreBase'
+				defaultTitle='Dramatis'
+				titleTemplate='%s | Dramatis'
 				title={documentTitle()}
 			/>
 

--- a/src/react/components/Footer.jsx
+++ b/src/react/components/Footer.jsx
@@ -6,7 +6,7 @@ const Footer = () => {
 		<footer className="footer">
 
 			<div className="footer__text footer__text--left">
-				TheatreBase
+				Dramatis
 			</div>
 
 			<div className="footer__text footer__text--right">

--- a/src/react/components/Header.jsx
+++ b/src/react/components/Header.jsx
@@ -9,7 +9,7 @@ const Header = () => {
 		<header className="header">
 
 			<Link to={'/'} className="header__component header__home-link">
-				TheatreBase
+				Dramatis
 			</Link>
 
 			<div className="header__component">

--- a/src/react/components/SearchBar.jsx
+++ b/src/react/components/SearchBar.jsx
@@ -67,7 +67,7 @@ const SearchBar = () => {
 			onSearch={handleSearch}
 			onChange={handleChange}
 			options={options}
-			placeholder='Search TheatreBase…'
+			placeholder='Search Dramatis…'
 			emptyLabel='No results found'
 			renderMenuItemChildren={(option, { text }) => (
 				<>


### PR DESCRIPTION
This PR changes the project name from **TheatreBase** to **Dramatis**.

Dramatis is Latin for 'of or relating to the drama' and is most commonly known in the context of 'dramatis personae' (literally 'persons of the drama').

It was also the name of an English synth-pop band from the early 1980s: https://en.wikipedia.org/wiki/Dramatis.

It is also a shorter title, meaning (as well as other places that might be an advantage) more of the word will appear in the browser tab when many tabs are open (or the browser window is narrow) and less of the document title text can display.

An obvious idea for a logo would be to incorporate the tragedy and comedy masks — the symmetry of the 'a's (i.e. the third and fifth characters) could be used for this purpose.

TheatreBase also has some drawbacks:
- theatre/theater has different spellings in the UK and US (which may result in needing to acquire more domain names to account for attempts to visit URLs of both spellings)
- its initialism, TB, is an abbreviation of tuberculosis
- the name was something of a play of it sounding similar to 'database' (i.e. a database of theatrebase), though this is not particularly obvious and it reads more of it being a base for theatre, and it's not entirely clear what that is