### PR TITLE
Upgrade eslint-plugin-mocha 10.5.0 -> 11.1.0

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,9 +19,9 @@ const compat = new FlatCompat({
 export default [
 	...compat.extends(
 		'eslint:recommended',
-		'plugin:mocha/recommended',
 		'plugin:react/recommended'
 	),
+	mochaPlugin.configs.recommended,
 	{
 		settings: {
 			react: {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "chai": "6.0.1",
     "concurrently": "9.2.1",
     "eslint": "9.36.0",
-    "eslint-plugin-mocha": "10.5.0",
+    "eslint-plugin-mocha": "11.1.0",
     "eslint-plugin-react": "7.37.5",
     "globals": "16.4.0",
     "lintspaces-cli": "1.0.0",


### PR DESCRIPTION
This PR upgrades eslint-plugin-mocha to the current latest version.

If the changes applied in `eslint.config.js` are not made then running `npm run lint` will result in the following error:

```
Oops! Something went wrong! :(

ESLint: 9.36.0

ESLint couldn't find the config "plugin:mocha/recommended" to extend from. Please check that the name of the config is correct.

The config "plugin:mocha/recommended" was referenced from the config file in "".

If you still have problems, please stop by https://eslint.org/chat/help to chat with the team.
```