### PR TITLE
Upgrade react-router 7.6.3 -> 7.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-bootstrap-typeahead": "6.4.1",
     "react-dom": "19.1.1",
     "react-redux": "9.2.0",
-    "react-router": "7.6.3",
+    "react-router": "7.9.1",
     "redux-logger": "3.0.6",
     "serve-favicon": "2.5.1"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -57,6 +57,15 @@ const clientScriptsBundle = {
 	watch: {
 		clearScreen: false
 	},
+	onwarn: (warning, warn) => {
+		if (
+			warning.code === 'MODULE_LEVEL_DIRECTIVE' &&
+			/"use client"/.test(warning.message || '')
+		) {
+			return; // Silence only this specific warning.
+		}
+		warn(warning); // Keep all other warnings.
+	},
 	plugins: [
 		nodeResolve({
 			browser: true,


### PR DESCRIPTION
This PR upgrades react-router to the current latest version.

Without the changes applied to `rollup.config.js`, the following logs will appear when running `npm run build` or when a re-build is triggered by a change in the codebase when the server is running.

```
(!) node_modules/react-router/dist/development/index.mjs (11:0): Module level directives cause errors when bundled, "use client" in "node_modules/react-router/dist/development/index.mjs" was ignored.
/{path}/dramatis-cms/node_modules/react-router/dist/development/index.mjs:11:0
 9:  * @license MIT
10:  */
11: "use client";
    ^
12: import {
13:   RSCDefaultRootErrorBoundary,
```

These started appearing as of react-router v7.7.0: https://github.com/remix-run/react-router/blob/main/CHANGELOG.md#v771.

> Unstable Changes
> ⚠️ [Unstable features](https://reactrouter.com/community/api-development-strategy#unstable-flags) are not recommended for production use
>
> - `react-router` - RSC Data Mode: fix bug where routes with errors weren't forced to revalidate when `shouldRevalidate` returned `false` (https://github.com/remix-run/react-router/pull/14026)
> - `react-router` - RSC Data Mode: fix `Matched leaf route at location "/..." does not have an element or Component` warnings when error boundaries are rendered (https://github.com/remix-run/react-router/pull/14021)

ChatGPT's explanation is:
> Short version: nothing’s “broken.” You’re pulling **React Router’s ESM build** that contains the RSC marker `"use client"`. **Rollup can’t preserve per-module directives** when it concatenates modules, so it warns:
>
> Module level directives cause errors when bundled, "use client" … was ignored
>
> That’s a known limitation/behavior in Rollup. In a plain client-side React app (no React Server Components), this warning is safe to ignore.
>
> **Why you see it**
> 
> Your bundle path shows `react-router/dist/development/index.mjs` which includes `"use client"`. Rollup drops that directive during bundling and emits the warning.

Closes #252 