### PR TITLE
Handle unfound paths in API router

### DIFF
--- a/src/server/api-router.js
+++ b/src/server/api-router.js
@@ -119,4 +119,11 @@ router.put('/venues/:uuid', (request, response, next) => instancesPutController(
 router.delete('/venues/:uuid', (request, response, next) => instancesDeleteController(request, response, next));
 router.get('/venues', (request, response, next) => listsGetController(request, response, next));
 
+router.use((request, response, next) => {
+	const error = new Error('Not Found');
+	error.status = 404;
+
+	return next(error);
+});
+
 export default router;


### PR DESCRIPTION
This PR adds handling for unfound paths in the API router.

Below examples are from when a request is made to `/locales` if the [corresponding route](https://github.com/andygout/dramatis-cms/blob/f8691026eb5ad3b0a9f8a3b3486fd77b6733d083/src/server/api-router.js#L69) is commented out.

### Before

Currently, if the client makes a request to the API with a path that it cannot find then the response looks like:

<img width="803" height="670" alt="api-router-before" src="https://github.com/user-attachments/assets/66a0b80e-1ac0-40ed-90b9-9124230d716d" />

### After
<img width="804" height="669" alt="api-router-after" src="https://github.com/user-attachments/assets/c8a569a3-e88a-485d-a2b1-63caa109fc93" />